### PR TITLE
Make skills distributable via npx skills add

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ $ opendcl
 
 OpenDCL reads your scene context and modifies existing code without overwriting it.
 
+## Use with Any AI Agent
+
+Install just the skills into your preferred AI coding agent — no opendcl installation required:
+
+```bash
+# Install all Decentraland skills (Claude Code, Cursor, Codex, Windsurf, and 35+ more)
+npx skills add dcl-regenesislabs/opendcl
+
+# List available skills first
+npx skills add dcl-regenesislabs/opendcl --list
+
+# Install specific skills only
+npx skills add dcl-regenesislabs/opendcl --skill create-scene --skill multiplayer-sync
+
+# Install globally (available in all projects)
+npx skills add dcl-regenesislabs/opendcl -g
+```
+
+This uses the open [skills](https://github.com/vercel-labs/skills) CLI to copy SKILL.md files into your agent's skills directory.
+
+> **Note:** The full OpenDCL agent adds auto TypeScript validation, scene context detection, and slash commands (`/preview`, `/init`, `/deploy`) on top of these skills.
+
 ## Commands
 
 | Command | Description |

--- a/skills/add-3d-models/SKILL.md
+++ b/skills/add-3d-models/SKILL.md
@@ -94,7 +94,8 @@ GltfContainer.create(child, { src: 'models/hat.glb' })
 ## Free 3D Models
 
 For free CC0-licensed 3D models suitable for Decentraland, read the catalog at:
-`{baseDir}/../../context/open-source-3d-assets.md`
+`context/open-source-3d-assets.md` (in the opendcl repo root). If unavailable locally, fetch from:
+https://raw.githubusercontent.com/dcl-regenesislabs/opendcl/main/context/open-source-3d-assets.md
 
 This catalog contains 991+ models organized by themed collections (Cyberpunk, Medieval, MomusPark, etc.) with direct download URLs.
 


### PR DESCRIPTION
## Summary

- Replace `{baseDir}` reference in `add-3d-models` skill with a repo-relative path and raw GitHub fallback URL, so non-pi agents can resolve the asset catalog
- Add "Use with Any AI Agent" section to README with `npx skills add` usage examples

## Test plan

- [x] `npm test` — 162/162 tests pass
- [x] `npm run lint` — clean