### PR TITLE
Add compact tool output for write and read

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The result: **more creators building more scenes, faster.**
 - **TypeScript validation** — catches type errors immediately after writing code
 - **Free 3D asset catalog** — 900+ CC0-licensed models the agent can suggest and help you use
 - **Permission gate** — prompts for confirmation before destructive bash commands or writes to sensitive files
+- **Compact tool output** — write shows path + size instead of file content, read shows a 5-line preview instead of 10
 - **Session persistence** — pick up where you left off across sessions
 
 ## Quick Start

--- a/src/compact-tool-renderers.ts
+++ b/src/compact-tool-renderers.ts
@@ -1,0 +1,135 @@
+/**
+ * Compact tool output renderers for built-in tools (write, read).
+ *
+ * Pi-coding-agent's built-in renderer shows verbose output: write shows 10 lines
+ * of file content, read shows 10 lines of preview. This module provides compact
+ * alternatives that reduce terminal noise when the agent writes/reads many files.
+ *
+ * These are wired in via a monkey-patch on InteractiveMode.getRegisteredToolDefinition
+ * in src/index.ts — they provide renderCall/renderResult without replacing execution logic.
+ */
+
+import { Text } from "@mariozechner/pi-tui";
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { homedir } from "node:os";
+
+/** Shorten absolute paths to tilde notation (mirrors pi's internal shortenPath) */
+function shortenPath(path: string): string {
+  const home = homedir();
+  if (path.startsWith(home)) {
+    return `~${path.slice(home.length)}`;
+  }
+  return path;
+}
+
+/** Replace tabs with spaces for consistent rendering */
+function replaceTabs(text: string): string {
+  return text.replace(/\t/g, "    ");
+}
+
+/** Partial tool definition — only the fields ToolExecutionComponent checks */
+interface CompactToolDef {
+  name: string;
+  renderCall?: (args: Record<string, unknown>, theme: Theme) => Text;
+  renderResult?: (
+    result: { content: Array<{ type: string; text?: string }>; details?: unknown },
+    options: { expanded: boolean; isPartial: boolean },
+    theme: Theme,
+  ) => Text;
+}
+
+const READ_PREVIEW_LINES = 5;
+
+const writeRenderer: CompactToolDef = {
+  name: "write",
+  renderCall(args, theme) {
+    const rawPath = typeof args.path === "string" ? args.path : null;
+    const content = typeof args.content === "string" ? args.content : null;
+    const path = rawPath !== null ? shortenPath(rawPath) : null;
+    const invalidArg = theme.fg("error", "[invalid arg]");
+
+    let text =
+      theme.fg("toolTitle", theme.bold("write")) +
+      " " +
+      (path === null ? invalidArg : path ? theme.fg("accent", path) : theme.fg("toolOutput", "..."));
+
+    if (content !== null) {
+      const lines = content.split("\n").length;
+      const chars = content.length;
+      text += theme.fg("muted", ` (${chars} chars, ${lines} lines)`);
+    }
+
+    return new Text(text, 0, 0);
+  },
+};
+
+const readRenderer: CompactToolDef = {
+  name: "read",
+  renderCall(args, theme) {
+    const rawPath = typeof args.path === "string" ? args.path : null;
+    const path = rawPath !== null ? shortenPath(rawPath) : null;
+    const offset = args.offset as number | undefined;
+    const limit = args.limit as number | undefined;
+    const invalidArg = theme.fg("error", "[invalid arg]");
+
+    let pathDisplay =
+      path === null ? invalidArg : path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
+
+    if (offset !== undefined || limit !== undefined) {
+      const startLine = offset ?? 1;
+      const endLine = limit !== undefined ? startLine + limit - 1 : "";
+      pathDisplay += theme.fg("warning", `:${startLine}${endLine ? `-${endLine}` : ""}`);
+    }
+
+    return new Text(theme.fg("toolTitle", theme.bold("read")) + " " + pathDisplay, 0, 0);
+  },
+  renderResult(result, { expanded }, theme) {
+    const textBlocks = result.content?.filter((c) => c.type === "text") || [];
+    const output = textBlocks.map((c) => c.text || "").join("\n");
+    if (!output) return new Text("", 0, 0);
+
+    const lines = output.split("\n");
+
+    const maxLines = expanded ? lines.length : READ_PREVIEW_LINES;
+    const displayLines = lines.slice(0, maxLines);
+    const remaining = lines.length - maxLines;
+
+    let text = displayLines.map((line) => theme.fg("toolOutput", replaceTabs(line))).join("\n");
+
+    if (remaining > 0) {
+      text += theme.fg("muted", `\n... (${remaining} more lines, ctrl+o to expand)`);
+    }
+
+    const details = result.details as Record<string, unknown> | undefined;
+    const truncation = details?.truncation as Record<string, unknown> | undefined;
+    if (truncation?.truncated) {
+      if (truncation.firstLineExceedsLimit) {
+        text += "\n" + theme.fg("warning", "[First line exceeds size limit]");
+      } else if (truncation.truncatedBy === "lines") {
+        text +=
+          "\n" +
+          theme.fg(
+            "warning",
+            `[Truncated: showing ${truncation.outputLines} of ${truncation.totalLines} lines]`,
+          );
+      } else {
+        text += "\n" + theme.fg("warning", `[Truncated: ${truncation.outputLines} lines shown]`);
+      }
+    }
+
+    return new Text(text, 0, 0);
+  },
+};
+
+const renderers = new Map<string, CompactToolDef>([
+  ["write", writeRenderer],
+  ["read", readRenderer],
+]);
+
+/**
+ * Returns a partial tool definition with compact renderCall/renderResult
+ * for supported built-in tools, or undefined for tools we don't override.
+ */
+export function getCompactToolDefinition(toolName: string): CompactToolDef | undefined {
+  return renderers.get(toolName);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 
 import { main, InteractiveMode } from "@mariozechner/pi-coding-agent";
 import { isDev } from "./utils.js";
+import { getCompactToolDefinition } from "./compact-tool-renderers.js";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -80,6 +81,17 @@ const _showWarning = InteractiveMode.prototype.showWarning;
 InteractiveMode.prototype.showWarning = function (msg: string) {
   if (msg.startsWith("No models available")) return;
   _showWarning.call(this, msg);
+};
+
+// Compact tool output — override built-in write/read renderers to reduce terminal noise.
+// When a built-in tool has no custom renderCall/renderResult, pi shows verbose output.
+// By returning compact renderers from getRegisteredToolDefinition, the ToolExecutionComponent
+// uses them instead (see shouldUseBuiltInRenderer() in tool-execution.js).
+const _getToolDef = (InteractiveMode.prototype as any).getRegisteredToolDefinition;
+(InteractiveMode.prototype as any).getRegisteredToolDefinition = function (toolName: string) {
+  const original = _getToolDef.call(this, toolName);
+  if (original) return original;
+  return getCompactToolDefinition(toolName);
 };
 
 main(args).catch((err) => {

--- a/tests/integration/wiring.test.ts
+++ b/tests/integration/wiring.test.ts
@@ -88,6 +88,11 @@ describe("index.ts wiring", () => {
     }
   });
 
+  it("compact tool renderers are wired via getRegisteredToolDefinition patch", () => {
+    expect(INDEX_SRC).toContain("getRegisteredToolDefinition");
+    expect(INDEX_SRC).toContain("getCompactToolDefinition");
+  });
+
   it("every .ts extension directory (plan-mode) is referenced in index.ts", () => {
     const allReferenced = new Set([...loopExtensions, ...standalonePushes]);
 

--- a/tests/unit/compact-tool-renderers.test.ts
+++ b/tests/unit/compact-tool-renderers.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { getCompactToolDefinition } from "../../src/compact-tool-renderers.js";
+import { Theme } from "@mariozechner/pi-coding-agent";
+import { homedir } from "node:os";
+
+// Minimal theme for testing — all colors are neutral so we can inspect text content
+const fgColors = Object.fromEntries(
+  [
+    "accent", "border", "borderAccent", "borderMuted", "success", "error",
+    "warning", "muted", "dim", "text", "thinkingText", "userMessageText",
+    "customMessageText", "customMessageLabel", "toolTitle", "toolOutput",
+    "mdHeading", "mdLink", "mdLinkUrl", "mdCode", "mdCodeBlock",
+    "mdCodeBlockBorder", "mdQuote", "mdQuoteBorder", "mdHr", "mdListBullet",
+    "toolDiffAdded", "toolDiffRemoved", "toolDiffContext", "syntaxComment",
+    "syntaxKeyword", "syntaxFunction", "syntaxVariable", "syntaxString",
+    "syntaxNumber", "syntaxType", "syntaxOperator", "syntaxPunctuation",
+    "thinkingOff", "thinkingMinimal", "thinkingLow", "thinkingMedium",
+    "thinkingHigh", "thinkingXhigh", "bashMode",
+  ].map((k) => [k, 0xffffff]),
+);
+const bgColors = Object.fromEntries(
+  [
+    "selectedBg", "userMessageBg", "customMessageBg",
+    "toolPendingBg", "toolSuccessBg", "toolErrorBg",
+  ].map((k) => [k, 0x000000]),
+);
+
+const theme = new Theme(
+  fgColors as any,
+  bgColors as any,
+  "truecolor",
+);
+
+describe("getCompactToolDefinition", () => {
+  it("returns a definition for 'write'", () => {
+    const def = getCompactToolDefinition("write");
+    expect(def).toBeDefined();
+    expect(def!.renderCall).toBeTypeOf("function");
+    expect(def!.renderResult).toBeUndefined();
+  });
+
+  it("returns a definition for 'read'", () => {
+    const def = getCompactToolDefinition("read");
+    expect(def).toBeDefined();
+    expect(def!.renderCall).toBeTypeOf("function");
+    expect(def!.renderResult).toBeTypeOf("function");
+  });
+
+  it("returns undefined for 'edit' (no override)", () => {
+    expect(getCompactToolDefinition("edit")).toBeUndefined();
+  });
+
+  it("returns undefined for 'bash' (no override)", () => {
+    expect(getCompactToolDefinition("bash")).toBeUndefined();
+  });
+
+  it("returns undefined for unknown tools", () => {
+    expect(getCompactToolDefinition("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("write renderCall", () => {
+  const def = getCompactToolDefinition("write")!;
+
+  it("renders path and char count", () => {
+    const component = def.renderCall!(
+      { path: "/tmp/test.ts", content: "hello world" },
+      theme,
+    );
+    const lines = component.render(120);
+    const output = lines.join("\n");
+    expect(output).toContain("write");
+    expect(output).toContain("test.ts");
+    expect(output).toContain("11 chars");
+    expect(output).toContain("1 lines");
+  });
+
+  it("shows line count for multiline content", () => {
+    const content = "line1\nline2\nline3\nline4\nline5";
+    const component = def.renderCall!(
+      { path: "/tmp/file.ts", content },
+      theme,
+    );
+    const output = component.render(120).join("\n");
+    expect(output).toContain("5 lines");
+  });
+
+  it("handles missing path gracefully", () => {
+    const component = def.renderCall!({ content: "x" }, theme);
+    const output = component.render(120).join("\n");
+    expect(output).toContain("write");
+    // Missing path (not a string) → shows invalid arg indicator
+    expect(output).toContain("[invalid arg]");
+  });
+
+  it("shows streaming placeholder for empty path", () => {
+    const component = def.renderCall!({ path: "", content: "" }, theme);
+    const output = component.render(120).join("\n");
+    expect(output).toContain("write");
+    expect(output).toContain("...");
+  });
+
+  it("shortens home directory paths", () => {
+    const home = homedir();
+    const component = def.renderCall!(
+      { path: `${home}/project/file.ts`, content: "x" },
+      theme,
+    );
+    const output = component.render(120).join("\n");
+    expect(output).toContain("~/project/file.ts");
+    expect(output).not.toContain(home);
+  });
+});
+
+describe("read renderCall", () => {
+  const def = getCompactToolDefinition("read")!;
+
+  it("renders path", () => {
+    const component = def.renderCall!(
+      { path: "/tmp/file.ts" },
+      theme,
+    );
+    const output = component.render(120).join("\n");
+    expect(output).toContain("read");
+    expect(output).toContain("file.ts");
+  });
+
+  it("renders offset and limit", () => {
+    const component = def.renderCall!(
+      { path: "/tmp/file.ts", offset: 10, limit: 20 },
+      theme,
+    );
+    const output = component.render(120).join("\n");
+    expect(output).toContain(":10-29");
+  });
+});
+
+describe("read renderResult", () => {
+  const def = getCompactToolDefinition("read")!;
+
+  it("shows 5 preview lines when collapsed", () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
+    const result = {
+      content: [{ type: "text", text: lines.join("\n") }],
+    };
+    const component = def.renderResult!(result, { expanded: false, isPartial: false }, theme);
+    const rendered = component.render(120).join("\n");
+
+    // Should contain first 5 lines
+    expect(rendered).toContain("line 1");
+    expect(rendered).toContain("line 5");
+    // Should NOT contain line 6+
+    expect(rendered).not.toContain("line 6");
+    // Should show remaining count
+    expect(rendered).toContain("15 more lines");
+  });
+
+  it("shows all lines when expanded", () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`);
+    const result = {
+      content: [{ type: "text", text: lines.join("\n") }],
+    };
+    const component = def.renderResult!(result, { expanded: true, isPartial: false }, theme);
+    const rendered = component.render(120).join("\n");
+
+    expect(rendered).toContain("line 1");
+    expect(rendered).toContain("line 10");
+    expect(rendered).not.toContain("more lines");
+  });
+
+  it("shows truncation warning", () => {
+    const result = {
+      content: [{ type: "text", text: "line 1\nline 2" }],
+      details: {
+        truncation: {
+          truncated: true,
+          truncatedBy: "lines",
+          outputLines: 200,
+          totalLines: 500,
+        },
+      },
+    };
+    const component = def.renderResult!(result, { expanded: false, isPartial: false }, theme);
+    const rendered = component.render(120).join("\n");
+    expect(rendered).toContain("Truncated");
+    expect(rendered).toContain("200");
+    expect(rendered).toContain("500");
+  });
+
+  it("handles empty result", () => {
+    const result = { content: [{ type: "text", text: "" }] };
+    const component = def.renderResult!(result, { expanded: false, isPartial: false }, theme);
+    const rendered = component.render(120).join("\n");
+    expect(rendered).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Override pi's built-in verbose renderers for `write` and `read` tools to reduce terminal noise
- **write** now shows `write ~/path/file.ts (1234 chars, 5 lines)` — one line, no file content preview (was 10 lines of source)
- **read** now shows a 5-line preview instead of 10
- Wired via `getRegisteredToolDefinition` monkey-patch (same pattern as `showWarning`), so extension-registered tools still take priority

## What could break

- If pi renames or removes `getRegisteredToolDefinition`, the patch silently stops working and tools revert to built-in verbose rendering (safe fallback)
- Custom renderers don't have access to the file path in `renderResult`, so read preview uses plain text instead of syntax highlighting

## How to test

- `npm test` — 259 tests pass (includes 16 new renderer tests + wiring check)
- `npm run build && node dist/index.js` in a scene dir, ask agent to create files — write shows path + size on one line, read shows 5-line preview