### PR TITLE
Rename package to @dcl-regenesislabs/opendcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenDCL is a terminal-based AI agent that understands Decentraland's SDK, compon
 
 ```bash
 # Install
-npm install -g opendcl
+npm install -g @dcl-regenesislabs/opendcl
 
 # Run in any directory
 opendcl
@@ -148,7 +148,7 @@ opendcl/
 
 ```bash
 # Clone and install
-git clone https://github.com/decentraland/opendcl.git
+git clone https://github.com/dcl-regenesislabs/opendcl.git
 cd opendcl
 npm install
 
@@ -227,7 +227,7 @@ Contributions are welcome! The easiest way to contribute is by adding or improvi
 3. Test that the skill loads: `npm test`
 4. Submit a pull request
 
-For bugs and feature requests, please [open an issue](https://github.com/decentraland/opendcl/issues).
+For bugs and feature requests, please [open an issue](https://github.com/dcl-regenesislabs/opendcl/issues).
 
 ## License
 

--- a/extensions/dcl-update-check.ts
+++ b/extensions/dcl-update-check.ts
@@ -9,20 +9,28 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const NPM_REGISTRY_URL = "https://registry.npmjs.org/@dcl-regenesislabs/opendcl/latest";
 const FETCH_TIMEOUT_MS = 5000;
+const PACKAGE_JSON_PATH = join(__dirname, "..", "package.json");
+
+/** Read and parse the project's package.json. */
+function readPackageJson(): { name?: string; version?: string } {
+  try {
+    return JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+/** Read the package name from package.json. */
+export function getPackageName(): string {
+  return readPackageJson().name || "@dcl-regenesislabs/opendcl";
+}
 
 /** Read the installed version from package.json. */
 export function getInstalledVersion(): string {
-  try {
-    const pkg = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
-    return pkg.version || "0.0.0";
-  } catch {
-    return "0.0.0";
-  }
+  return readPackageJson().version || "0.0.0";
 }
 
 /** Fetch the latest published version from npm registry. */
@@ -30,7 +38,8 @@ export async function fetchLatestVersion(): Promise<string | null> {
   try {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    const res = await fetch(NPM_REGISTRY_URL, { signal: controller.signal });
+    const registryUrl = `https://registry.npmjs.org/${getPackageName()}/latest`;
+    const res = await fetch(registryUrl, { signal: controller.signal });
     clearTimeout(timeout);
     if (!res.ok) return null;
     const data = (await res.json()) as { version?: string };
@@ -42,14 +51,14 @@ export async function fetchLatestVersion(): Promise<string | null> {
 
 /** Compare two semver strings. Returns true if latest is newer than current. */
 export function isNewerVersion(current: string, latest: string): boolean {
-  const cur = current.split(".").map((n) => parseInt(n, 10) || 0);
-  const lat = latest.split(".").map((n) => parseInt(n, 10) || 0);
-  const len = Math.max(cur.length, lat.length);
-  for (let i = 0; i < len; i++) {
-    const c = cur[i] || 0;
-    const l = lat[i] || 0;
-    if (l > c) return true;
-    if (l < c) return false;
+  const currentParts = current.split(".").map((n) => parseInt(n, 10) || 0);
+  const latestParts = latest.split(".").map((n) => parseInt(n, 10) || 0);
+  const length = Math.max(currentParts.length, latestParts.length);
+  for (let i = 0; i < length; i++) {
+    const currentPart = currentParts[i] || 0;
+    const latestPart = latestParts[i] || 0;
+    if (latestPart > currentPart) return true;
+    if (latestPart < currentPart) return false;
   }
   return false;
 }
@@ -61,7 +70,7 @@ const extension: ExtensionFactory = (pi) => {
     // Fire-and-forget: don't block session startup
     fetchLatestVersion().then((latest) => {
       if (latest && isNewerVersion(getInstalledVersion(), latest)) {
-        ctx.ui.notify(`OpenDCL v${latest} is available. Run: npm install -g @dcl-regenesislabs/opendcl`, "info");
+        ctx.ui.notify(`OpenDCL v${latest} is available. Run: npm install -g ${getPackageName()}`, "info");
       }
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "opendcl",
+  "name": "@dcl-regenesislabs/opendcl",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "opendcl",
+      "name": "@dcl-regenesislabs/opendcl",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opendcl",
+  "name": "@dcl-regenesislabs/opendcl",
   "version": "0.1.0",
   "description": "AI coding assistant for Decentraland SDK7 scene development",
   "type": "module",
@@ -13,9 +13,15 @@
     "configDir": ".opendcl"
   },
   "pi": {
-    "extensions": ["./extensions"],
-    "skills": ["./skills"],
-    "prompts": ["./prompts"]
+    "extensions": [
+      "./extensions"
+    ],
+    "skills": [
+      "./skills"
+    ],
+    "prompts": [
+      "./prompts"
+    ]
   },
   "scripts": {
     "build": "tsc",
@@ -31,8 +37,9 @@
     "sdk7",
     "ai",
     "coding-agent",
-    "pi-package",
-    "scene-builder"
+    "scene-builder",
+    "scene-creator",
+    "sdk7-scenes"
   ],
   "author": "Decentraland",
   "license": "Apache-2.0",

--- a/tests/integration/dcl-update-check.test.ts
+++ b/tests/integration/dcl-update-check.test.ts
@@ -8,6 +8,7 @@ import { createMockPi } from "../helpers/mock-pi.js";
 import {
   isNewerVersion,
   getInstalledVersion,
+  getPackageName,
 } from "../../extensions/dcl-update-check.js";
 import extension from "../../extensions/dcl-update-check.js";
 
@@ -40,6 +41,12 @@ describe("dcl-update-check", () => {
 
     it("handles minor bump with lower patch", () => {
       expect(isNewerVersion("1.0.9", "1.1.0")).toBe(true);
+    });
+  });
+
+  describe("getPackageName", () => {
+    it("returns the scoped package name", () => {
+      expect(getPackageName()).toBe("@dcl-regenesislabs/opendcl");
     });
   });
 


### PR DESCRIPTION
## Summary
- Rename npm package from `opendcl` to `@dcl-regenesislabs/opendcl` in package.json and package-lock.json
- Update README install command, clone URL, and issues link to `dcl-regenesislabs/opendcl`
- Refactor `dcl-update-check.ts` to read the package name dynamically from package.json via `getPackageName()` instead of hardcoding it; also deduplicate file reads with a shared `readPackageJson()` helper and improve variable names in `isNewerVersion()`
- Add test for `getPackageName()` returning the scoped name
- Fix `bin` entry to use `./dist/index.js` (with leading `./`)

## What could break
- Anyone installing via `npm install -g opendcl` will need to use the new scoped name
- The npm registry URL for update checks now uses the scoped package name — will 404 until the scoped package is published

## How to test
- `npm test` — all 261 tests pass
- Verify `require('./package.json').name` returns `@dcl-regenesislabs/opendcl`
- After publishing, confirm `npm install -g @dcl-regenesislabs/opendcl` installs correctly and the `opendcl` bin is available