### PR TITLE
Fix update check not detecting newer stable over snapshots

### DIFF
--- a/extensions/dcl-update-check.ts
+++ b/extensions/dcl-update-check.ts
@@ -49,18 +49,31 @@ export async function fetchLatestVersion(): Promise<string | null> {
   }
 }
 
+/** Strip pre-release and build metadata from a version string (e.g. "1.0.0-beta" -> "1.0.0"). */
+function stripPreRelease(version: string): string {
+  return version.replace(/[-+].*$/, "");
+}
+
 /** Compare two semver strings. Returns true if latest is newer than current. */
 export function isNewerVersion(current: string, latest: string): boolean {
-  const currentParts = current.split(".").map((n) => parseInt(n, 10) || 0);
-  const latestParts = latest.split(".").map((n) => parseInt(n, 10) || 0);
+  const currentBase = stripPreRelease(current);
+  const latestBase = stripPreRelease(latest);
+
+  const currentParts = currentBase.split(".").map((n) => parseInt(n, 10) || 0);
+  const latestParts = latestBase.split(".").map((n) => parseInt(n, 10) || 0);
   const length = Math.max(currentParts.length, latestParts.length);
+
   for (let i = 0; i < length; i++) {
     const currentPart = currentParts[i] || 0;
     const latestPart = latestParts[i] || 0;
     if (latestPart > currentPart) return true;
     if (latestPart < currentPart) return false;
   }
-  return false;
+
+  // Base versions equal: pre-release < stable (e.g., 0.1.0-snapshot < 0.1.0)
+  const currentHasPreRelease = current !== currentBase;
+  const latestHasPreRelease = latest !== latestBase;
+  return currentHasPreRelease && !latestHasPreRelease;
 }
 
 const extension: ExtensionFactory = (pi) => {

--- a/tests/integration/dcl-update-check.test.ts
+++ b/tests/integration/dcl-update-check.test.ts
@@ -42,6 +42,22 @@ describe("dcl-update-check", () => {
     it("handles minor bump with lower patch", () => {
       expect(isNewerVersion("1.0.9", "1.1.0")).toBe(true);
     });
+
+    it("treats stable as newer than snapshot with same base version", () => {
+      expect(isNewerVersion("0.1.0-22234509684.commit-63dfd19", "0.1.0")).toBe(true);
+    });
+
+    it("treats snapshot as not newer than stable with same base version", () => {
+      expect(isNewerVersion("0.1.0", "0.1.0-123.commit-abc")).toBe(false);
+    });
+
+    it("detects newer version even when current has pre-release suffix", () => {
+      expect(isNewerVersion("0.1.0-123.commit-abc", "0.2.0")).toBe(true);
+    });
+
+    it("treats two pre-releases with same base as equal", () => {
+      expect(isNewerVersion("0.1.0-abc", "0.1.0-def")).toBe(false);
+    });
   });
 
   describe("getPackageName", () => {


### PR DESCRIPTION
## Summary
- `isNewerVersion()` now strips pre-release/build suffixes before comparing semver segments
- When base versions are equal, a pre-release is correctly treated as older than a stable release (per semver spec)
- Fixes the case where CI snapshot versions like `0.1.0-22234509684.commit-63dfd19` compared equal to stable `0.1.0`, suppressing update notifications

## What could break
- None expected — only changes the comparison when pre-release suffixes are present, and existing tests all still pass

## How to test
- `npm test` — 388 tests pass, including 4 new pre-release comparison cases
- Verify manually: `isNewerVersion("0.1.0-22234509684.commit-63dfd19", "0.1.0")` now returns `true`