### PR TITLE
Suppress pi changelog/update leaking into OpenDCL

### DIFF
--- a/extensions/dcl-update-check.ts
+++ b/extensions/dcl-update-check.ts
@@ -83,7 +83,7 @@ const extension: ExtensionFactory = (pi) => {
     // Fire-and-forget: don't block session startup
     fetchLatestVersion().then((latest) => {
       if (latest && isNewerVersion(getInstalledVersion(), latest)) {
-        ctx.ui.notify(`OpenDCL v${latest} is available. Run: npm install -g ${getPackageName()}`, "info");
+        ctx.ui.notify(`OpenDCL v${latest} is available. Run: npm install -g ${getPackageName()}`, "warning");
       }
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,22 @@ InteractiveMode.prototype.showWarning = function (msg: string) {
   _showWarning.call(this, msg);
 };
 
+// Suppress pi's "What's New" changelog notification on startup — it shows pi's
+// own version/changes, which confuses OpenDCL users.
+(InteractiveMode.prototype as any).getChangelogForDisplay = function () {
+  return undefined;
+};
+
+// Override pi's built-in /changelog command — it shows pi's CHANGELOG.md,
+// not OpenDCL's. The command is hardcoded in handleEditorSubmit before extension
+// commands, so monkey-patching is the only way to intercept it.
+const opendclVersion = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf-8")).version;
+(InteractiveMode.prototype as any).handleChangelogCommand = function () {
+  (this as any).showStatus(
+    `OpenDCL v${opendclVersion} — https://github.com/dcl-regenesislabs/opendcl/releases/tag/${opendclVersion}`,
+  );
+};
+
 // Compact tool output — override built-in write/read renderers to reduce terminal noise.
 // When a built-in tool has no custom renderCall/renderResult, pi shows verbose output.
 // By returning compact renderers from getRegisteredToolDefinition, the ToolExecutionComponent

--- a/tests/integration/dcl-update-check.test.ts
+++ b/tests/integration/dcl-update-check.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createMockPi } from "../helpers/mock-pi.js";
 import {
   isNewerVersion,
@@ -73,6 +75,16 @@ describe("dcl-update-check", () => {
 
     it("does not return 0.0.0", () => {
       expect(getInstalledVersion()).not.toBe("0.0.0");
+    });
+  });
+
+  describe("notification type", () => {
+    it("uses warning notification type for update availability", () => {
+      const src = readFileSync(
+        join(import.meta.dirname, "../../extensions/dcl-update-check.ts"),
+        "utf-8",
+      );
+      expect(src).toMatch(/ctx\.ui\.notify\([\s\S]+?,\s*"warning"\)/);
     });
   });
 

--- a/tests/integration/wiring.test.ts
+++ b/tests/integration/wiring.test.ts
@@ -93,6 +93,11 @@ describe("index.ts wiring", () => {
     expect(INDEX_SRC).toContain("getCompactToolDefinition");
   });
 
+  it("pi changelog patches are wired (getChangelogForDisplay + handleChangelogCommand)", () => {
+    expect(INDEX_SRC).toContain("getChangelogForDisplay");
+    expect(INDEX_SRC).toContain("handleChangelogCommand");
+  });
+
   it("every .ts extension directory (plan-mode) is referenced in index.ts", () => {
     const allReferenced = new Set([...loopExtensions, ...standalonePushes]);
 


### PR DESCRIPTION
## Summary
- Monkey-patch `getChangelogForDisplay` to suppress pi's "What's New" startup notification (shows pi's version, not OpenDCL's)
- Override `handleChangelogCommand` to redirect `/changelog` to OpenDCL's GitHub releases page
- Change update-check notification from `"info"` (dim/invisible) to `"warning"` (visible)

## What could break
- If pi renames `getChangelogForDisplay` or `handleChangelogCommand` internally, the patches become no-ops (benign — pi's default behavior returns)
- The `"warning"` notification type renders more prominently, which is the intent

## How to test
1. `npm test` — all 390 tests pass (2 new)
2. `npm run build && node dist/index.js` — no pi "What's New" box on startup
3. Type `/changelog` — shows OpenDCL releases link instead of pi's CHANGELOG.md