### PR TITLE
Fix orphaned background processes on session exit

### DIFF
--- a/extensions/dcl-preview.ts
+++ b/extensions/dcl-preview.ts
@@ -41,7 +41,16 @@ const extension: ExtensionFactory = (pi) => {
 
   function cleanupPreview(): void {
     if (previewProcess && !previewProcess.killed) {
-      previewProcess.kill();
+      const pid = previewProcess.pid;
+      if (pid) {
+        try {
+          process.kill(-pid, "SIGTERM");
+        } catch {
+          // Process group already exited
+        }
+      } else {
+        previewProcess.kill();
+      }
     }
     previewProcess = null;
     processes.delete("preview");
@@ -68,6 +77,7 @@ const extension: ExtensionFactory = (pi) => {
         cwd: sceneRoot,
         stdio: "pipe",
         shell: true,
+        detached: true,
       });
 
       processes.set("preview", {

--- a/extensions/process-registry.ts
+++ b/extensions/process-registry.ts
@@ -23,3 +23,18 @@ if (!_global[REGISTRY_KEY]) {
 
 /** Shared registry of running background processes, keyed by unique id. */
 export const processes = _global[REGISTRY_KEY] as Map<string, BackgroundProcess>;
+
+const EXIT_HANDLER_KEY = Symbol.for("opendcl.exitHandler");
+if (!_global[EXIT_HANDLER_KEY]) {
+  _global[EXIT_HANDLER_KEY] = true;
+  process.on("exit", () => {
+    for (const [id, proc] of processes) {
+      try {
+        proc.kill();
+      } catch {
+        // Best-effort
+      }
+      processes.delete(id);
+    }
+  });
+}

--- a/tests/unit/extensions/dcl-preview.test.ts
+++ b/tests/unit/extensions/dcl-preview.test.ts
@@ -63,6 +63,14 @@ describe("dcl-preview extension", () => {
     expect(content).toContain("decentraland.zone/bevy-web");
     expect(content).toContain("bevyUrlFound");
   });
+
+  it("spawns with detached: true for process group cleanup", () => {
+    expect(content).toContain("detached: true");
+  });
+
+  it("kills the process group via process.kill(-pid)", () => {
+    expect(content).toContain("process.kill(-pid");
+  });
 });
 
 describe("selectPreviewUrl", () => {

--- a/tests/unit/extensions/process-registry.test.ts
+++ b/tests/unit/extensions/process-registry.test.ts
@@ -1,42 +1,32 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const EXTENSIONS_DIR = join(import.meta.dirname, "../../../extensions");
 
 describe("process-registry", () => {
-  it("file exists and exports processes Map", async () => {
-    const content = await readFile(
-      join(EXTENSIONS_DIR, "process-registry.ts"),
-      "utf-8"
-    );
+  let content: string;
+
+  beforeAll(async () => {
+    content = await readFile(join(EXTENSIONS_DIR, "process-registry.ts"), "utf-8");
+  });
+
+  it("file exists and exports processes Map", () => {
     expect(content).toContain("export const processes");
     expect(content).toContain("Map<string, BackgroundProcess>");
   });
 
-  it("exports BackgroundProcess interface with required fields", async () => {
-    const content = await readFile(
-      join(EXTENSIONS_DIR, "process-registry.ts"),
-      "utf-8"
-    );
+  it("exports BackgroundProcess interface with required fields", () => {
     expect(content).toContain("export interface BackgroundProcess");
     expect(content).toContain("name: string");
     expect(content).toContain("kill: () => void");
   });
 
-  it("includes optional info field", async () => {
-    const content = await readFile(
-      join(EXTENSIONS_DIR, "process-registry.ts"),
-      "utf-8"
-    );
+  it("includes optional info field", () => {
     expect(content).toContain("info?: string");
   });
 
-  it("uses globalThis singleton pattern to survive module cache bypass", async () => {
-    const content = await readFile(
-      join(EXTENSIONS_DIR, "process-registry.ts"),
-      "utf-8"
-    );
+  it("uses globalThis singleton pattern to survive module cache bypass", () => {
     expect(content).toContain('Symbol.for("opendcl.processes")');
     expect(content).toContain("globalThis");
   });
@@ -44,5 +34,14 @@ describe("process-registry", () => {
   it("can import and use the registry", async () => {
     const { processes } = await import("../../../extensions/process-registry.js");
     expect(processes).toBeInstanceOf(Map);
+  });
+
+  it("registers a process.on('exit') safety net handler", () => {
+    expect(content).toContain('process.on("exit"');
+  });
+
+  it("uses Symbol guard to prevent duplicate exit handler registration", () => {
+    expect(content).toContain('Symbol.for("opendcl.exitHandler")');
+    expect(content).toContain("EXIT_HANDLER_KEY");
   });
 });


### PR DESCRIPTION
## Summary
- Preview server spawned with `shell: true` caused `kill()` to only terminate the `/bin/sh` wrapper, leaving `npx @dcl/sdk-commands start` and the dev server as orphans
- Spawn with `detached: true` and kill the entire process group via `process.kill(-pid, "SIGTERM")` so all child processes are cleaned up
- Add a `process.on('exit')` safety net in the process registry to kill registered processes even if `session_shutdown` doesn't fire (crash, unhandled exception)

## What could break
- On Windows, `detached: true` behaves differently (creates a new console window); since the codebase targets macOS/Linux this should be fine, but worth noting
- The negative-PID kill is Unix-specific; if `pid` is undefined for some reason, falls back to the old `previewProcess.kill()` behavior

## How to test
1. `npm test` — all 394 tests pass
2. Run opendcl, start `/preview`, exit the session
3. Verify with `ps aux | grep sdk-commands` that no orphaned processes remain