### PR TITLE
Fix case-sensitive GitHub URLs for MomusPark models

### DIFF
--- a/context/open-source-3d-assets.md
+++ b/context/open-source-3d-assets.md
@@ -47,88 +47,88 @@ Versatile park environment with Greek/Roman architectural ruins, wildlife, and l
 
 | Model | URL | Description |
 |-------|-----|-------------|
-| Bush_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Bush_01_Art.glb) | Decorative bush |
-| Bush_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Bush_02_Art.glb) | Bush variant |
-| Bush_03_art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Bush_03_art.glb) | Bush variant |
-| Tree_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Tree_01_Art.glb) | Park tree |
-| Tree_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Tree_02_Art.glb) | Park tree variant |
-| Tree_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Tree_03_Art.glb) | Park tree variant |
-| Tree_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Tree_04_Art.glb) | Park tree variant |
-| Tree_Trunk_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Tree_Trunk_01_Art.glb) | Standalone tree trunk |
-| Flower_01_a | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Flower_01_a.glb) | Flower cluster |
-| Flower_01_b | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Flower_01_b.glb) | Flower cluster variant |
-| Flower_02_a_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Flower_02_a_Art.glb) | Flower type 2 |
-| Flower_02_b_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Flower_02_b_Art.glb) | Flower type 2 variant |
-| Flower_03_a | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Flower_03_a.glb) | Flower type 3 |
-| Flower_03_b | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Flower_03_b.glb) | Flower type 3 variant |
-| Grass_01_a | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Grass_01_a.glb) | Grass patch |
-| Grass_01_b | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Grass_01_b.glb) | Grass patch variant |
-| Mushroom_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Mushroom_01_Art.glb) | Decorative mushroom |
-| Mushroom_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Mushroom_02_Art.glb) | Mushroom variant |
-| Root_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Root_01_Art.glb) | Exposed tree root |
-| Root_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Root_02_Art.glb) | Exposed tree root variant |
-| Log_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Log_01_Art.glb) | Fallen log |
+| Bush_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Bush_01_Art.glb) | Decorative bush |
+| Bush_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Bush_02_Art.glb) | Bush variant |
+| Bush_03_art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Bush_03_art.glb) | Bush variant |
+| Tree_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_01_Art.glb) | Park tree |
+| Tree_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_02_Art.glb) | Park tree variant |
+| Tree_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_03_Art.glb) | Park tree variant |
+| Tree_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_04_Art.glb) | Park tree variant |
+| Tree_Trunk_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_Trunk_01_Art.glb) | Standalone tree trunk |
+| Flower_01_a | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Flower_01_a.glb) | Flower cluster |
+| Flower_01_b | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Flower_01_b.glb) | Flower cluster variant |
+| Flower_02_a_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Flower_02_a_Art.glb) | Flower type 2 |
+| Flower_02_b_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Flower_02_b_Art.glb) | Flower type 2 variant |
+| Flower_03_a | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Flower_03_a.glb) | Flower type 3 |
+| Flower_03_b | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Flower_03_b.glb) | Flower type 3 variant |
+| Grass_01_a | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Grass_01_a.glb) | Grass patch |
+| Grass_01_b | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Grass_01_b.glb) | Grass patch variant |
+| Mushroom_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Mushroom_01_Art.glb) | Decorative mushroom |
+| Mushroom_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Mushroom_02_Art.glb) | Mushroom variant |
+| Root_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Root_01_Art.glb) | Exposed tree root |
+| Root_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Root_02_Art.glb) | Exposed tree root variant |
+| Log_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Log_01_Art.glb) | Fallen log |
 
 ### Architecture and Structures
 
 | Model | URL | Description |
 |-------|-----|-------------|
-| Str_Amphitheater_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Amphitheater_01_Art.glb) | Greek amphitheater |
-| Str_Column_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Column_04_Art.glb) | Classical column |
-| Str_Fountain_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Fountain_01_Art.glb) | Decorative fountain |
-| Str_Ruins_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Ruins_01_Art.glb) | Ancient ruins piece |
-| Str_Ruins_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Ruins_02_Art.glb) | Ancient ruins piece |
-| Str_Ruins_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Ruins_03_Art.glb) | Ancient ruins piece |
-| Str_Ruins_05_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Str_Ruins_05_Art.glb) | Ancient ruins piece |
-| Statue_greek_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Statue_greek_01_Art.glb) | Greek statue |
-| Statue_greek_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Statue_greek_02_Art.glb) | Greek statue variant |
-| Shelter_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Shelter_Art.glb) | Park shelter structure |
+| Str_Amphitheater_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Amphitheater_01_Art.glb) | Greek amphitheater |
+| Str_Column_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Column_04_Art.glb) | Classical column |
+| Str_Fountain_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Fountain_01_Art.glb) | Decorative fountain |
+| Str_Ruins_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Ruins_01_Art.glb) | Ancient ruins piece |
+| Str_Ruins_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Ruins_02_Art.glb) | Ancient ruins piece |
+| Str_Ruins_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Ruins_03_Art.glb) | Ancient ruins piece |
+| Str_Ruins_05_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Str_Ruins_05_Art.glb) | Ancient ruins piece |
+| Statue_greek_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Statue_greek_01_Art.glb) | Greek statue |
+| Statue_greek_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Statue_greek_02_Art.glb) | Greek statue variant |
+| Shelter_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Shelter_Art.glb) | Park shelter structure |
 
 ### Park Furniture and Paths
 
 | Model | URL | Description |
 |-------|-----|-------------|
-| Bench_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Bench_01_Art.glb) | Park bench |
-| Fence_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Fence_01_Art.glb) | Wooden fence section |
-| Fence_01_Post_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Fence_01_Post_Art.glb) | Fence post |
-| Signal_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Signal_01_Art.glb) | Park sign |
-| Signal_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Signal_02_Art.glb) | Park sign variant |
-| Path_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Path_01_Art.glb) | Walking path segment |
-| Path_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Path_02_Art.glb) | Walking path segment |
-| Path_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Path_03_Art.glb) | Walking path segment |
-| Path_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Path_04_Art.glb) | Walking path segment |
-| Brick_Step_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Brick_Step_01_Art.glb) | Brick stepping stones |
+| Bench_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Bench_01_Art.glb) | Park bench |
+| Fence_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Fence_01_Art.glb) | Wooden fence section |
+| Fence_01_Post_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Fence_01_Post_Art.glb) | Fence post |
+| Signal_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Signal_01_Art.glb) | Park sign |
+| Signal_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Signal_02_Art.glb) | Park sign variant |
+| Path_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Path_01_Art.glb) | Walking path segment |
+| Path_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Path_02_Art.glb) | Walking path segment |
+| Path_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Path_03_Art.glb) | Walking path segment |
+| Path_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Path_04_Art.glb) | Walking path segment |
+| Brick_Step_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Brick_Step_01_Art.glb) | Brick stepping stones |
 
 ### Terrain and Water
 
 | Model | URL | Description |
 |-------|-----|-------------|
-| LAND_Floor | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/LAND_Floor.glb) | Ground terrain tile |
-| Terrain_Amount_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Terrain_Amount_01_Art.glb) | Terrain elevation |
-| Terrain_Amount_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Terrain_Amount_02_Art.glb) | Terrain elevation variant |
-| Rock_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Rock_01_Art.glb) | Rock formation |
-| Rock_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Rock_02_Art.glb) | Rock formation |
-| Rock_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Rock_03_Art.glb) | Rock formation |
-| Rock_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Rock_04_Art.glb) | Rock formation |
-| Rock_05_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Rock_05_Art.glb) | Rock formation |
-| Floating_Island_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Floating_Island_01_Art.glb) | Fantasy floating island |
-| Floating_Island_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Floating_Island_02_Art.glb) | Floating island variant |
-| Water_Pond_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Water_Pond_01_Art.glb) | Pond water surface |
-| Water_plane_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Water_plane_Art.glb) | Flat water plane |
-| Water_Fall_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Water_Fall_01_Art.glb) | Waterfall |
-| Water_Fall_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Water_Fall_02_Art.glb) | Waterfall variant |
-| Water_FX_2_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Water_FX_2_Art.glb) | Water splash effect |
+| LAND_Floor | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/LAND_Floor.glb) | Ground terrain tile |
+| Terrain_Amount_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Terrain_Amount_01_Art.glb) | Terrain elevation |
+| Terrain_Amount_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Terrain_Amount_02_Art.glb) | Terrain elevation variant |
+| Rock_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Rock_01_Art.glb) | Rock formation |
+| Rock_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Rock_02_Art.glb) | Rock formation |
+| Rock_03_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Rock_03_Art.glb) | Rock formation |
+| Rock_04_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Rock_04_Art.glb) | Rock formation |
+| Rock_05_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Rock_05_Art.glb) | Rock formation |
+| Floating_Island_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Floating_Island_01_Art.glb) | Fantasy floating island |
+| Floating_Island_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Floating_Island_02_Art.glb) | Floating island variant |
+| Water_Pond_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Water_Pond_01_Art.glb) | Pond water surface |
+| Water_plane_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Water_plane_Art.glb) | Flat water plane |
+| Water_Fall_01_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Water_Fall_01_Art.glb) | Waterfall |
+| Water_Fall_02_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Water_Fall_02_Art.glb) | Waterfall variant |
+| Water_FX_2_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Water_FX_2_Art.glb) | Water splash effect |
 
 ### Wildlife
 
 | Model | URL | Description |
 |-------|-----|-------------|
-| DeerArmature | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/DeerArmature.glb) | Rigged deer |
-| MountainLion | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/MountainLion.glb) | Mountain lion |
-| Owl | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Owl.glb) | Owl |
-| PigArmature | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/PigArmature.glb) | Rigged pig |
-| Butterfly | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Butterfly.glb) | Butterfly |
-| Skydoor_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Skydoor_Art.glb) | Fantasy sky portal |
+| DeerArmature | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/DeerArmature.glb) | Rigged deer |
+| MountainLion | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/MountainLion.glb) | Mountain lion |
+| Owl | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Owl.glb) | Owl |
+| PigArmature | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/PigArmature.glb) | Rigged pig |
+| Butterfly | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Butterfly.glb) | Butterfly |
+| Skydoor_Art | [Download](https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Skydoor_Art.glb) | Fantasy sky portal |
 
 ---
 

--- a/skills/add-3d-models/SKILL.md
+++ b/skills/add-3d-models/SKILL.md
@@ -115,7 +115,7 @@ GltfContainer.create(entity, { src: 'models/arcade_machine.glb' })
 Read `context/open-source-3d-assets.md` for free CC0-licensed models from Polygonal Mind, organized by 18 themed collections (MomusPark, Medieval Fair, Cyberpunk, Sci-fi, etc.) with direct GitHub download URLs.
 
 ```bash
-curl -o models/tree.glb "https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/momuspark/Tree_01_Art.glb"
+curl -o models/tree.glb "https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_01_Art.glb"
 ```
 
 ### How to suggest models


### PR DESCRIPTION
## Summary
- Fix 62 broken download URLs in `context/open-source-3d-assets.md` and 1 in `skills/add-3d-models/SKILL.md`
- The GitHub directory is `projects/MomusPark/` (PascalCase) but all URLs used `projects/momuspark/` (lowercase), causing 404s on case-sensitive `raw.githubusercontent.com`

## What could break
- Nothing — this is a pure URL case correction in documentation/catalog files

## How to test
- `grep -c 'projects/momuspark/' context/open-source-3d-assets.md` returns 0
- `grep -c 'projects/MomusPark/' context/open-source-3d-assets.md` returns 62
- Spot-check: `curl -sI "https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_01_Art.glb"` returns HTTP 200
- `npm test` passes (394/394)