### PR TITLE
Fix ctx.reload crash when init tool is called by LLM

### DIFF
--- a/extensions/dcl-init.ts
+++ b/extensions/dcl-init.ts
@@ -43,7 +43,7 @@ const extension: ExtensionFactory = (pi) => {
     parameters: Type.Object({}),
     async execute(_id, _params, _signal, _onUpdate, ctx) {
       const result = await initScene(ctx.cwd, pi);
-      if (!result.isError) await ctx.reload();
+      if (!result.isError && 'reload' in ctx) await (ctx as any).reload();
       return { content: [{ type: "text" as const, text: result.message }], details: undefined };
     },
   });


### PR DESCRIPTION
## Summary
- Guard `ctx.reload()` in the `init` tool's `registerTool` execute handler with a runtime `'reload' in ctx` check
- The `execute` callback receives `ExtensionContext` (no `reload`), not `ExtensionCommandContext` — calling it unconditionally crashes at runtime

## What could break
- None. The `/init` slash command path is unchanged. The tool path now simply skips the reload when `reload` isn't available.

## How to test
- `npm test` — all 395 tests pass
- Trigger the `init` tool via LLM (previously crashed with `ctx.reload is not a function`)