### PR TITLE
Fix context file paths resolving relative to scene dir

### DIFF
--- a/skills/add-3d-models/SKILL.md
+++ b/skills/add-3d-models/SKILL.md
@@ -97,7 +97,7 @@ Always check both asset catalogs before suggesting the user create or find their
 
 ### Creator Hub Asset Packs (2,700+ models)
 
-Read `context/asset-packs-catalog.md` for official Decentraland models across 12 themed packs (Cyberpunk, Fantasy, Gallery, Sci-fi, Western, Pirates, etc.) with furniture, structures, decorations, nature, and more.
+Read `{baseDir}/../../context/asset-packs-catalog.md` for official Decentraland models across 12 themed packs (Cyberpunk, Fantasy, Gallery, Sci-fi, Western, Pirates, etc.) with furniture, structures, decorations, nature, and more.
 
 To use a Creator Hub model:
 ```bash
@@ -112,7 +112,7 @@ GltfContainer.create(entity, { src: 'models/arcade_machine.glb' })
 
 ### Open Source CC0 Models (991 models)
 
-Read `context/open-source-3d-assets.md` for free CC0-licensed models from Polygonal Mind, organized by 18 themed collections (MomusPark, Medieval Fair, Cyberpunk, Sci-fi, etc.) with direct GitHub download URLs.
+Read `{baseDir}/../../context/open-source-3d-assets.md` for free CC0-licensed models from Polygonal Mind, organized by 18 themed collections (MomusPark, Medieval Fair, Cyberpunk, Sci-fi, etc.) with direct GitHub download URLs.
 
 ```bash
 curl -o models/tree.glb "https://raw.githubusercontent.com/ToxSam/cc0-models-Polygonal-Mind/main/projects/MomusPark/Tree_01_Art.glb"

--- a/skills/audio-video/SKILL.md
+++ b/skills/audio-video/SKILL.md
@@ -204,7 +204,7 @@ To make audio non-spatial (same volume everywhere), there's no built-in flag —
 
 Always check the audio catalog before creating placeholder sound file references. It contains 50 free sounds from the Creator Hub asset packs.
 
-Read `context/audio-catalog.md` for music tracks (ambient, dance, medieval, sci-fi, etc.), ambient sounds (birds, city, factory, etc.), interaction sounds (buttons, doors, levers, chests), sound effects (explosions, sirens, bells), and game mechanic sounds (win/lose, heal, respawn, damage).
+Read `{baseDir}/../../context/audio-catalog.md` for music tracks (ambient, dance, medieval, sci-fi, etc.), ambient sounds (birds, city, factory, etc.), interaction sounds (buttons, doors, levers, chests), sound effects (explosions, sirens, bells), and game mechanic sounds (win/lose, heal, respawn, damage).
 
 To use a catalog sound:
 ```bash

--- a/skills/create-scene/SKILL.md
+++ b/skills/create-scene/SKILL.md
@@ -24,9 +24,9 @@ Never manually create scene.json, package.json, or tsconfig.json — the SDK tem
 
 Before writing scene code, check both asset catalogs for free models that match the user's theme:
 
-1. Read `context/asset-packs-catalog.md` (2,700+ Creator Hub models — furniture, structures, decorations, nature, etc.)
-2. Read `context/open-source-3d-assets.md` (991 CC0 models — cyberpunk, medieval, nature, sci-fi, etc.)
-3. Read `context/audio-catalog.md` (50 free sounds — music, ambient, SFX, game mechanics, etc.)
+1. Read `{baseDir}/../../context/asset-packs-catalog.md` (2,700+ Creator Hub models — furniture, structures, decorations, nature, etc.)
+2. Read `{baseDir}/../../context/open-source-3d-assets.md` (991 CC0 models — cyberpunk, medieval, nature, sci-fi, etc.)
+3. Read `{baseDir}/../../context/audio-catalog.md` (50 free sounds — music, ambient, SFX, game mechanics, etc.)
 4. Suggest matching models and sounds to the user
 5. Download selected models into the scene's `models/` directory:
    ```bash

--- a/skills/player-avatar/SKILL.md
+++ b/skills/player-avatar/SKILL.md
@@ -279,4 +279,4 @@ Beyond the commonly used anchor points, the full list includes:
 - **Never use `Transform.getMutable(engine.PlayerEntity)` to move the player** — it does not work. Always use `movePlayerTo` from `~system/RestrictedActions`
 - `Transform.get(engine.PlayerEntity)` is valid for **reading** position only
 
-For component field details, see `context/components-reference.md`.
+For component field details, see `{baseDir}/../../context/components-reference.md`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,10 +34,14 @@ if (!existsSync(settingsPath)) {
 // Build args: start with user's CLI args
 const args = process.argv.slice(2);
 
-// Inject DCL system prompt (read from prompts/system.md, strip YAML frontmatter)
+// Inject DCL system prompt (strip YAML frontmatter, resolve context/ paths to absolute)
 if (!args.includes("--system-prompt")) {
   const raw = readFileSync(join(packageDir, "prompts/system.md"), "utf-8");
-  const systemPrompt = raw.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+  const contextDir = join(packageDir, "context");
+  const systemPrompt = raw
+    .replace(/^---\n[\s\S]*?\n---\n/, "")
+    .replace(/context\/([\w-]+\.md)/g, (_, filename) => join(contextDir, filename))
+    .trim();
   args.push("--system-prompt", systemPrompt);
 }
 

--- a/tests/integration/wiring.test.ts
+++ b/tests/integration/wiring.test.ts
@@ -88,6 +88,25 @@ describe("index.ts wiring", () => {
     }
   });
 
+  it("system prompt resolves context/ paths to absolute paths", () => {
+    // The system prompt is built by stripping frontmatter then replacing context/foo.md
+    // with absolute paths. Verify the replacement logic produces absolute paths.
+    const raw = readFileSync(join(ROOT, "prompts/system.md"), "utf-8");
+    const contextDir = join(ROOT, "context");
+    const systemPrompt = raw
+      .replace(/^---\n[\s\S]*?\n---\n/, "")
+      .replace(/context\/([\w-]+\.md)/g, (_: string, filename: string) => join(contextDir, filename))
+      .trim();
+
+    // After replacement, every context/foo.md should be an absolute path (preceded by /)
+    expect(systemPrompt).not.toMatch(/(?<!\/)context\/[\w-]+\.md/);
+
+    // Should contain absolute paths to the context directory
+    expect(systemPrompt).toContain(join(contextDir, "sdk7-cheat-sheet.md"));
+    expect(systemPrompt).toContain(join(contextDir, "open-source-3d-assets.md"));
+    expect(systemPrompt).toContain(join(contextDir, "asset-packs-catalog.md"));
+  });
+
   it("compact tool renderers are wired via getRegisteredToolDefinition patch", () => {
     expect(INDEX_SRC).toContain("getRegisteredToolDefinition");
     expect(INDEX_SRC).toContain("getCompactToolDefinition");

--- a/tests/unit/skills/skill-loading.test.ts
+++ b/tests/unit/skills/skill-loading.test.ts
@@ -116,6 +116,22 @@ describe("skill loading", () => {
     }
   });
 
+  it("skills use {baseDir} prefix for context file references", async () => {
+    const skills = await getAllSkillFiles();
+
+    for (const skill of skills) {
+      // Find all context/foo.md references and capture what precedes them
+      const refs = [...skill.content.matchAll(/(.{0,20})(context\/[\w-]+\.md)/g)];
+
+      for (const [, before, ref] of refs) {
+        expect(
+          before,
+          `${skill.dir}/SKILL.md has bare "${ref}" — use {baseDir}/../../context/filename.md instead`
+        ).toContain("{baseDir}");
+      }
+    }
+  });
+
   it("skills reference only existing context files", async () => {
     const skills = await getAllSkillFiles();
     const contextDir = join(import.meta.dirname, "../../../context");


### PR DESCRIPTION
## Summary

- Context paths like `context/asset-packs-catalog.md` in skills and the system prompt were resolved relative to the user's scene directory instead of the opendcl installation directory, causing ENOENT errors when the LLM tried to read them
- Skills now use `{baseDir}/../../context/` so pi resolves paths from the skill directory; system prompt paths are resolved to absolute paths at load time in `src/index.ts`
- Added regression tests to prevent bare `context/` references from being reintroduced

## What could break

- If a skill's directory depth relative to `context/` changes, the `../../` traversal would break — but this is already caught by the existing "skills reference only existing context files" test

## How to test

- Run `npm test` — all 397 tests pass, including 2 new regression tests
- Run the agent from a user scene directory and ask it to suggest 3D models — it should successfully read the asset catalogs