### PR TITLE
Hide /setup-ollama behind feature flag

### DIFF
--- a/extensions/dcl-setup-ollama.ts
+++ b/extensions/dcl-setup-ollama.ts
@@ -4,6 +4,8 @@
  * Registers the /setup-ollama command that walks users through
  * model selection and configuration for a free local LLM setup.
  * On session start, nudges users who have no provider configured.
+ *
+ * FEATURE FLAG: Set OPENDCL_ENABLE_OLLAMA_SETUP=1 to enable this command.
  */
 
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
@@ -206,6 +208,14 @@ export function ollamaPull(
 }
 
 const extension: ExtensionFactory = (pi) => {
+  // Feature flag: only register if explicitly enabled
+  const isEnabled = process.env.OPENDCL_ENABLE_OLLAMA_SETUP === "1";
+  
+  if (!isEnabled) {
+    // Extension loaded but not active — no commands registered
+    return;
+  }
+
   pi.on("session_start", async (_event, ctx) => {
     if (!(await isProviderConfigured())) {
       ctx.ui.notify(


### PR DESCRIPTION
## Summary

Hides the `/setup-ollama` command behind the `OPENDCL_ENABLE_OLLAMA_SETUP` environment variable.

## Changes

- Added feature flag check at the start of the extension factory
- Command is now **disabled by default**
- Set `OPENDCL_ENABLE_OLLAMA_SETUP=1` to enable the command
- All code remains in place for future use

## Why

This allows us to keep the Ollama setup functionality in the codebase while hiding it from users until it's ready for general availability.

## Testing

To test that it's disabled:
```bash
npm start
# /setup-ollama should not be available
```

To test that it can be enabled:
```bash
OPENDCL_ENABLE_OLLAMA_SETUP=1 npm start
# /setup-ollama should now be available
```