### PR TITLE
Gate all file access outside working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The result: **more creators building more scenes, faster.**
 - **Integrated commands** — `/init` to scaffold, `/preview` to launch the dev server, `/tasks` to manage running processes, `/review` to audit code
 - **TypeScript validation** — catches type errors immediately after writing code
 - **Free asset catalogs** — 2,700+ Creator Hub 3D models, 900+ CC0-licensed models, and 50 audio files the agent proactively suggests when building scenes
-- **Permission gate** — prompts for confirmation before destructive bash commands or writes to sensitive files
+- **Permission gate** — prompts for confirmation before destructive bash commands, writes to sensitive files, or any file access outside the working directory
 - **Compact tool output** — write shows path + size instead of file content, read shows a 5-line preview instead of 10
 - **Session persistence** — pick up where you left off across sessions
 

--- a/extensions/permissions/index.ts
+++ b/extensions/permissions/index.ts
@@ -7,25 +7,53 @@
  */
 
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
-import { classifyBashCommand, classifyFilePath } from "./utils.js";
+import { classifyBashCommand, classifyFilePath, isOutsideCwd, OUTSIDE_CWD_REASON } from "./utils.js";
+import { resolve } from "node:path";
 
-function blockResult(reason: string, detail: string): { block: true; reason: string } {
+type BlockResult = { block: true; reason: string };
+
+function blockResult(reason: string, detail: string): BlockResult {
   return {
     block: true,
     reason: `Blocked: ${reason}\n${detail}\nUse --no-permissions to allow in non-interactive mode.`,
   };
 }
 
-function denyResult(reason: string): { block: true; reason: string } {
+function denyResult(reason: string): BlockResult {
   return { block: true, reason: `User denied: ${reason}` };
 }
 
-const ALLOW = "Allow";
-const ALWAYS = "Always allow";
-const DENY = "Deny";
+const CHOICES = ["Allow", "Always allow", "Deny"] as const;
 
 const extension: ExtensionFactory = (pi) => {
   const sessionAllow = new Set<string>();
+  const allowedPaths = new Set<string>();
+
+  function isPathAllowed(resolvedPath: string): boolean {
+    for (const allowed of allowedPaths) {
+      if (resolvedPath === allowed || resolvedPath.startsWith(allowed + "/")) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Prompts the user for confirmation and handles their choice.
+   * Returns a BlockResult to deny, or undefined to allow.
+   */
+  async function promptOrBlock(
+    ctx: { hasUI: boolean; ui: { select: (title: string, options: string[]) => Promise<string | null> } },
+    reason: string,
+    detail: string,
+    onAlways: () => void,
+  ): Promise<BlockResult | undefined> {
+    if (!ctx.hasUI) return blockResult(reason, detail);
+
+    const choice = await ctx.ui.select(`${reason}\n${detail}`, [...CHOICES]);
+
+    if (choice === "Always allow") { onAlways(); return; }
+    if (choice === "Allow") return;
+    return denyResult(reason);
+  }
 
   pi.registerFlag("no-permissions", {
     description: "Disable permission gate (skip confirmation prompts for dangerous operations)",
@@ -43,33 +71,36 @@ const extension: ExtensionFactory = (pi) => {
       const reason = classifyBashCommand(command);
       if (!reason || sessionAllow.has(reason)) return;
 
-      if (!ctx.hasUI) return blockResult(reason, `Command: ${command}`);
-
-      const choice = await ctx.ui.select(
-        `${reason}\nCommand: ${command}`,
-        [ALLOW, ALWAYS, DENY],
-      );
-
-      if (choice === ALWAYS) { sessionAllow.add(reason); return; }
-      if (choice === ALLOW) return;
-      return denyResult(reason);
+      return promptOrBlock(ctx, reason, `Command: ${command}`, () => sessionAllow.add(reason));
     }
 
     if (toolName === "write" || toolName === "edit") {
       const filePath = (event.input as { path?: string }).path ?? "";
       const reason = filePath ? classifyFilePath(filePath, ctx.cwd) : null;
-      if (!reason || sessionAllow.has(reason)) return;
+      if (!reason) return;
 
-      if (!ctx.hasUI) return blockResult(reason, `Path: ${filePath}`);
+      if (reason === OUTSIDE_CWD_REASON) {
+        const resolved = resolve(ctx.cwd, filePath);
+        if (isPathAllowed(resolved)) return;
 
-      const choice = await ctx.ui.select(
-        `${reason}\nFile: ${filePath}`,
-        [ALLOW, ALWAYS, DENY],
-      );
+        return promptOrBlock(ctx, reason, `File: ${filePath}`, () => allowedPaths.add(resolved));
+      }
 
-      if (choice === ALWAYS) { sessionAllow.add(reason); return; }
-      if (choice === ALLOW) return;
-      return denyResult(reason);
+      if (sessionAllow.has(reason)) return;
+
+      return promptOrBlock(ctx, reason, `Path: ${filePath}`, () => sessionAllow.add(reason));
+    }
+
+    if (toolName === "read" || toolName === "grep" || toolName === "find" || toolName === "ls") {
+      const filePath = (event.input as { path?: string }).path ?? "";
+      if (!filePath) return;
+
+      const resolved = resolve(ctx.cwd, filePath);
+      const reason = isOutsideCwd(filePath, ctx.cwd);
+      if (!reason) return;
+      if (isPathAllowed(resolved)) return;
+
+      return promptOrBlock(ctx, reason, `Path: ${filePath}`, () => allowedPaths.add(resolved));
     }
   });
 };

--- a/extensions/permissions/utils.ts
+++ b/extensions/permissions/utils.ts
@@ -5,6 +5,8 @@
 
 import { resolve, relative } from "node:path";
 
+export const OUTSIDE_CWD_REASON = "Accesses path outside working directory";
+
 interface DenylistEntry {
   pattern: RegExp;
   reason: string;
@@ -75,8 +77,20 @@ export function classifyFilePath(filePath: string, projectRoot: string): string 
   const rel = relative(projectRoot, resolved);
 
   if (rel.startsWith("..")) {
-    return "File is outside the project root";
+    return OUTSIDE_CWD_REASON;
   }
 
   return findMatchingReason(SENSITIVE_FILE_PATTERNS, filePath);
+}
+
+/**
+ * Returns a reason string if the file path resolves outside the given cwd,
+ * or null if inside (or empty).
+ */
+export function isOutsideCwd(filePath: string, cwd: string): string | null {
+  if (!filePath) return null;
+  const resolved = resolve(cwd, filePath);
+  const rel = relative(cwd, resolved);
+  if (rel.startsWith("..")) return OUTSIDE_CWD_REASON;
+  return null;
 }

--- a/tests/integration/permissions.test.ts
+++ b/tests/integration/permissions.test.ts
@@ -213,9 +213,129 @@ describe("permissions extension", () => {
   });
 
   describe("read tool", () => {
-    it("does not gate read operations", async () => {
-      const { ctx, wasSelectCalled } = spyingContext({ cwd: "/home/user/project" });
+    const PROJECT_ROOT = "/home/user/project";
+
+    it("allows reads within cwd without prompting", async () => {
+      const { ctx, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
+      const result = await toolCallHandler({ toolName: "read", input: { path: "src/index.ts" } }, ctx);
+
+      expect(result).toBeUndefined();
+      expect(wasSelectCalled()).toBe(false);
+    });
+
+    it("allows reads of sensitive files within cwd without prompting", async () => {
+      const { ctx, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
       const result = await toolCallHandler({ toolName: "read", input: { path: ".env" } }, ctx);
+
+      expect(result).toBeUndefined();
+      expect(wasSelectCalled()).toBe(false);
+    });
+
+    it("blocks reads outside cwd when user denies", async () => {
+      const result = await toolCallHandler(
+        { toolName: "read", input: { path: "/etc/passwd" } },
+        selectingContext("Deny", { cwd: PROJECT_ROOT }),
+      );
+      expect(result).toEqual(expect.objectContaining({ block: true }));
+    });
+
+    it("allows reads outside cwd when user accepts", async () => {
+      const result = await toolCallHandler(
+        { toolName: "read", input: { path: "/etc/passwd" } },
+        selectingContext("Allow", { cwd: PROJECT_ROOT }),
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("blocks reads outside cwd in non-interactive mode", async () => {
+      const result = await toolCallHandler(
+        { toolName: "read", input: { path: "/etc/passwd" } },
+        createMockContext({ hasUI: false, cwd: PROJECT_ROOT }),
+      );
+      expect(result).toEqual(expect.objectContaining({ block: true }));
+    });
+
+    it("allows reads with no path (defaults to cwd)", async () => {
+      const { ctx, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
+      const result = await toolCallHandler({ toolName: "read", input: {} }, ctx);
+
+      expect(result).toBeUndefined();
+      expect(wasSelectCalled()).toBe(false);
+    });
+  });
+
+  describe("grep/find/ls tools", () => {
+    const PROJECT_ROOT = "/home/user/project";
+
+    for (const toolName of ["grep", "find", "ls"]) {
+      it(`${toolName}: allows within cwd without prompting`, async () => {
+        const { ctx, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
+        const result = await toolCallHandler({ toolName, input: { path: "src/" } }, ctx);
+
+        expect(result).toBeUndefined();
+        expect(wasSelectCalled()).toBe(false);
+      });
+
+      it(`${toolName}: prompts for paths outside cwd`, async () => {
+        const result = await toolCallHandler(
+          { toolName, input: { path: "/tmp/other" } },
+          selectingContext("Deny", { cwd: PROJECT_ROOT }),
+        );
+        expect(result).toEqual(expect.objectContaining({ block: true }));
+      });
+    }
+  });
+
+  describe("path-scoped session permissions", () => {
+    const PROJECT_ROOT = "/home/user/project";
+
+    it("'Always allow' auto-allows re-read of same path", async () => {
+      // Allow /etc/passwd with "Always allow"
+      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
+      await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx1);
+
+      // Re-read /etc/passwd → auto-allowed
+      const { ctx: ctx2, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
+      const result = await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx2);
+
+      expect(result).toBeUndefined();
+      expect(wasSelectCalled()).toBe(false);
+    });
+
+    it("'Always allow' for one path does NOT auto-allow a different path", async () => {
+      // Allow /etc/passwd
+      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
+      await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx1);
+
+      // /tmp/file.txt is different → still prompts
+      const result = await toolCallHandler(
+        { toolName: "read", input: { path: "/tmp/file.txt" } },
+        selectingContext("Deny", { cwd: PROJECT_ROOT }),
+      );
+      expect(result).toEqual(expect.objectContaining({ block: true }));
+    });
+
+    it("'Always allow' for directory auto-allows files under it (prefix match)", async () => {
+      // Allow /etc
+      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
+      await toolCallHandler({ toolName: "read", input: { path: "/etc" } }, ctx1);
+
+      // /etc/passwd is under /etc → auto-allowed
+      const { ctx: ctx2, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
+      const result = await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx2);
+
+      expect(result).toBeUndefined();
+      expect(wasSelectCalled()).toBe(false);
+    });
+
+    it("'Always allow' on read covers write/edit to same outside-cwd path", async () => {
+      // Allow /tmp/shared.ts via read
+      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
+      await toolCallHandler({ toolName: "read", input: { path: "/tmp/shared.ts" } }, ctx1);
+
+      // Write to /tmp/shared.ts → same allowedPaths → auto-allowed
+      const { ctx: ctx2, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
+      const result = await toolCallHandler({ toolName: "write", input: { path: "/tmp/shared.ts" } }, ctx2);
 
       expect(result).toBeUndefined();
       expect(wasSelectCalled()).toBe(false);

--- a/tests/unit/extensions/permissions.test.ts
+++ b/tests/unit/extensions/permissions.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { classifyBashCommand, classifyFilePath } from "../../../extensions/permissions/utils.js";
+import { classifyBashCommand, classifyFilePath, isOutsideCwd } from "../../../extensions/permissions/utils.js";
 
 describe("permissions utils", () => {
   describe("classifyBashCommand", () => {
@@ -104,8 +104,8 @@ describe("permissions utils", () => {
       ["package.json", "package manifest"],
       ["tsconfig.json", "TypeScript config"],
       [".git/config", "git internal"],
-      ["../../etc/passwd", "outside project root"],
-      ["/etc/passwd", "outside project root"],
+      ["../../etc/passwd", "outside working directory"],
+      ["/etc/passwd", "outside working directory"],
     ];
 
     it.each(sensitive)("%s → returns reason", (filePath) => {
@@ -143,6 +143,38 @@ describe("permissions utils", () => {
 
     it("reason for .git/ mentions git", () => {
       expect(classifyFilePath(".git/config", projectRoot)!.toLowerCase()).toContain("git");
+    });
+  });
+
+  describe("isOutsideCwd", () => {
+    const cwd = "/home/user/project";
+
+    const outside: [string, string][] = [
+      ["../../etc/passwd", "relative traversal"],
+      ["/etc/passwd", "absolute outside path"],
+      ["/tmp/file.txt", "absolute outside path"],
+      ["../sibling/file.ts", "relative sibling"],
+    ];
+
+    it.each(outside)("%s → returns reason (%s)", (filePath) => {
+      const reason = isOutsideCwd(filePath, cwd);
+      expect(reason).toBeTypeOf("string");
+      expect(reason!.toLowerCase()).toContain("outside");
+    });
+
+    const inside = [
+      "src/index.ts",
+      "./src/index.ts",
+      "README.md",
+      "a/b/c/d/e/f/deeply-nested.ts",
+    ];
+
+    it.each(inside.map((p) => [p]))("%s → returns null", (filePath) => {
+      expect(isOutsideCwd(filePath, cwd)).toBeNull();
+    });
+
+    it("empty string → returns null", () => {
+      expect(isOutsideCwd("", cwd)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Permission gate now prompts for `read`, `grep`, `find`, and `ls` when they access paths outside the working directory (previously only `write`/`edit` were gated)
- "Always allow" is path-prefix scoped: allowing `/etc` auto-allows `/etc/passwd` but not `/tmp/file.txt`
- Extracted `promptOrBlock` helper to deduplicate the prompt-select-handle pattern across all tool handlers
- Added `isOutsideCwd()` utility and `OUTSIDE_CWD_REASON` constant for consistent outside-cwd detection

## What could break
- Agents that previously read files outside the working directory freely will now be prompted — this is intentional but could interrupt automated workflows. Use `--no-permissions` to bypass.
- The reason string for outside-cwd changed from "File is outside the project root" to "Accesses path outside working directory" — any code matching on that exact string would need updating.

## How to test
- `npm test` — 436 tests pass (includes 20+ new permission tests)
- `npm run lint` — clean
- Manual: run `node dist/index.js` in a scene directory, ask the agent to read `/etc/hosts` — should prompt Allow/Always/Deny