### PR TITLE
Improve all 20 skills with decision trees, troubleshooting, and API fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,12 @@ Key lifecycle events: `session_start`, `before_agent_start`, `tool_call`, `tool_
 | `process-registry.ts` | Shared `Map<string, BackgroundProcess>` singleton (via globalThis) | Module export |
 | `permissions/index.ts` | Confirms dangerous bash & file write ops | `tool_call` + `registerFlag` |
 
-## Skills (19)
+## Skills (20)
 
 create-scene, add-3d-models, add-interactivity, build-ui, animations-tweens,
 multiplayer-sync, authoritative-server, audio-video, deploy-scene, deploy-worlds, optimize-scene,
 camera-control, lighting-environment, player-avatar, nft-blockchain, advanced-rendering, advanced-input, scene-runtime,
-visual-feedback
+visual-feedback, game-design
 
 Adding a skill = creating `skills/<name>/SKILL.md`. No code changes needed.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The result: **more creators building more scenes, faster.**
 - **Branded header** — on startup, displays a block-character "Decentraland" ASCII art banner with version and working directory. Falls back to a compact text header on narrow terminals
 - **Multi-provider LLM support** — works with Claude, OpenAI, Google, Ollama (free/local), OpenRouter, and more
 - **Scene-aware** — automatically detects your project's `scene.json`, SDK version, and entry points
-- **19 built-in skills** — scaffolding, 3D models, interactivity, UI, animations, multiplayer, authoritative server, audio/video, deployment (Genesis City & Worlds), optimization, camera control, lighting, player/avatar, NFT/blockchain, advanced rendering, advanced input, scene runtime, visual feedback
+- **20 built-in skills** — scaffolding, 3D models, interactivity, UI, animations, multiplayer, authoritative server, audio/video, deployment (Genesis City & Worlds), optimization, camera control, lighting, player/avatar, NFT/blockchain, advanced rendering, advanced input, scene runtime, visual feedback, game design
 - **Integrated commands** — `/init` to scaffold, `/preview` to launch the dev server, `/tasks` to manage running processes, `/review` to audit code
 - **TypeScript validation** — catches type errors immediately after writing code
 - **Free asset catalogs** — 2,700+ Creator Hub 3D models, 900+ CC0-licensed models, and 50 audio files the agent proactively suggests when building scenes
@@ -128,6 +128,7 @@ OpenDCL loads domain-specific skills on demand based on what you're asking:
 | `advanced-input` | Cursor state, movement restriction, WASD patterns |
 | `scene-runtime` | Async tasks, fetch, timers, realm info, restricted actions, testing |
 | `visual-feedback` | Use the screenshot tool to see your scene, verify changes, iterate visually |
+| `game-design` | Plan game architecture, scene limits, state management, MVP planning |
 
 ## How It Works
 
@@ -160,7 +161,7 @@ opendcl/
 │   ├── dcl-tasks.ts          # /tasks command (process manager)
 │   ├── process-registry.ts   # Shared background process registry
 │   └── permissions/           # Permission gate for dangerous operations
-├── skills/                   # 19 SKILL.md files (domain expertise)
+├── skills/                   # 20 SKILL.md files (domain expertise)
 ├── prompts/                  # System prompt + command templates
 ├── context/                  # SDK7 reference docs + asset catalog
 └── tests/                    # Vitest test suites

--- a/context/sdk7-cheat-sheet.md
+++ b/context/sdk7-cheat-sheet.md
@@ -18,8 +18,8 @@ import ReactEcs, { ReactEcsRenderer, UiEntity, Label, Button, Input, Dropdown } 
 import { movePlayerTo, teleportTo, triggerEmote, changeRealm,
   openExternalUrl, openNftDialog, triggerSceneEmote,
   copyToClipboard } from '~system/RestrictedActions'
-import { getSceneInformation, getRealm, readFile } from '~system/Runtime'
-import { getWorldTime, getExplorerInformation } from '~system/EnvironmentApi'
+import { getSceneInformation, getRealm, readFile, getWorldTime,
+  getExplorerInformation } from '~system/Runtime'
 import { signedFetch, getHeaders } from '~system/SignedFetch'
 import { getPlayer } from '@dcl/sdk/src/players'
 ```
@@ -136,7 +136,7 @@ ColliderLayer.CL_CUSTOM1 … CL_CUSTOM8  // user-defined layers
   "featureToggles": { "voiceChat": "enabled" },
   "worldConfiguration": {
     "name": "my-world.dcl.eth",
-    "skyboxConfig": { "fixedHour": 14.0 }
+    "skyboxConfig": { "fixedTime": 36000 }
   }
 }
 ```

--- a/skills/add-3d-models/SKILL.md
+++ b/skills/add-3d-models/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-3d-models
-description: Add 3D models (.glb/.gltf) to a Decentraland scene using GltfContainer. Covers loading models, positioning, scaling, colliders, and browsing the open-source 3D assets catalog for free CC0 models. Use when user wants to add models, import GLB files, or find free 3D assets.
+description: Add 3D models (.glb/.gltf) to a Decentraland scene using GltfContainer. Covers loading, positioning, scaling, colliders, parenting, and browsing 2,700+ free assets from the Creator Hub catalog and 991 CC0 models. Use when the user wants to add models, import GLB files, find free 3D assets, or set up model colliders. Do NOT use for materials/textures (see advanced-rendering) or model animations (see animations-tweens).
 ---
 
 # Adding 3D Models to Decentraland Scenes
@@ -144,6 +144,21 @@ engine.addSystem(() => {
   }
 })
 ```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| Model not visible | Wrong file path | Verify the file exists at the exact path relative to project root (e.g., `models/myModel.glb`) |
+| Model not visible | Position outside scene boundaries | Check Transform position is within 0-16 per parcel. Center of 1-parcel scene is (8, 0, 8) |
+| Model not visible | Scale is 0 or very small | Check `Transform.scale` — default is (1,1,1). Try larger values if model was exported very small |
+| Model not visible | Behind the camera | Move the avatar or rotate to look in the model's direction |
+| Model loads but looks wrong | Y-up vs Z-up mismatch | Decentraland uses Y-up. Re-export from Blender with "Y Up" checked |
+| "FINISHED_WITH_ERROR" load state | Corrupted or unsupported .glb | Re-export the model. Use `.glb` (binary GLTF) format. Ensure no unsupported extensions |
+| Clicking model does nothing | Missing collider | Add `visibleMeshesCollisionMask: ColliderLayer.CL_POINTER` to `GltfContainer` or add `MeshCollider` |
+
+> **Need to optimize models for scene limits?** See the **optimize-scene** skill for triangle budgets and LOD patterns.
+> **Need animations from your model?** See the **animations-tweens** skill for playing GLTF animation clips with Animator.
 
 ## Model Best Practices
 

--- a/skills/add-interactivity/SKILL.md
+++ b/skills/add-interactivity/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: add-interactivity
-description: Add click handlers, hover effects, pointer events, triggers, and raycasting to Decentraland scene entities. Use when user wants to make objects clickable, add interactions, detect player proximity, or handle user input.
+description: Add click handlers, hover effects, pointer events, trigger areas, raycasting, and global input to Decentraland scene entities. Use when the user wants to make objects clickable, add hover effects, detect player proximity, handle E/F key actions, or cast rays. Do NOT use for advanced input patterns like movement restriction, cursor lock, or WASD control (see advanced-input). Do NOT use for screen-space UI buttons (see build-ui).
 ---
 
 # Adding Interactivity to Decentraland Scenes
+
+## Decision Tree
+
+| Need | Approach | API |
+|------|----------|-----|
+| Click/hover on a specific entity | Pointer events | `pointerEventsSystem.onPointerDown()` |
+| Detect player entering an area | Trigger area | `TriggerArea` + `triggerAreaEventsSystem` |
+| Poll key state every frame | Global input | `inputSystem.isTriggered()` / `isPressed()` |
+| Detect objects in a direction | Raycasting | `raycastSystem` or `Raycast` component |
+| Read cursor position / lock state | Cursor state | `PointerLock`, `PrimaryPointerInfo` |
+
+---
 
 ## Pointer Events (Click / Hover)
 
@@ -32,15 +44,29 @@ pointerEventsSystem.onPointerDown(
 )
 ```
 
-### Available Input Actions
+### All Input Actions
 ```typescript
-InputAction.IA_POINTER   // Left click / primary
-InputAction.IA_PRIMARY   // E key
-InputAction.IA_SECONDARY // F key
-InputAction.IA_ACTION_3  // Key 1
-InputAction.IA_ACTION_4  // Key 2
-InputAction.IA_ACTION_5  // Key 3
-InputAction.IA_ACTION_6  // Key 4
+InputAction.IA_POINTER    // Left mouse button
+InputAction.IA_PRIMARY    // E key
+InputAction.IA_SECONDARY  // F key
+InputAction.IA_ACTION_3   // 1 key
+InputAction.IA_ACTION_4   // 2 key
+InputAction.IA_ACTION_5   // 3 key
+InputAction.IA_ACTION_6   // 4 key
+InputAction.IA_JUMP       // Space key
+InputAction.IA_FORWARD    // W key
+InputAction.IA_BACKWARD   // S key
+InputAction.IA_LEFT       // A key
+InputAction.IA_RIGHT      // D key
+InputAction.IA_WALK       // Shift key
+```
+
+### All Event Types
+```typescript
+PointerEventType.PET_DOWN         // Button pressed
+PointerEventType.PET_UP           // Button released
+PointerEventType.PET_HOVER_ENTER  // Cursor enters entity
+PointerEventType.PET_HOVER_LEAVE  // Cursor leaves entity
 ```
 
 ### Pointer Up (Release)
@@ -76,6 +102,8 @@ GltfContainer.create(entity, {
   visibleMeshesCollisionMask: ColliderLayer.CL_POINTER
 })
 ```
+
+---
 
 ## Trigger Areas (Proximity Detection)
 
@@ -121,9 +149,66 @@ Transform.create(mover, { position: Vector3.create(8, 0, 8) })
 MeshCollider.setBox(mover, ColliderLayer.CL_CUSTOM1)
 ```
 
+---
+
 ## Raycasting
 
-Cast rays to detect objects in a direction:
+### Raycast Direction Types
+
+Four direction modes are available:
+
+```typescript
+// 1. Local direction — relative to entity rotation
+{ $case: 'localDirection', localDirection: Vector3.Forward() }
+
+// 2. Global direction — world-space, ignores entity rotation
+{ $case: 'globalDirection', globalDirection: Vector3.Down() }
+
+// 3. Global target — aim at a world position
+{ $case: 'globalTarget', globalTarget: Vector3.create(10, 0, 10) }
+
+// 4. Target entity — aim at another entity
+{ $case: 'targetEntity', targetEntity: entityId }
+```
+
+### Callback-Based Raycasting (Recommended)
+
+```typescript
+import { raycastSystem, RaycastQueryType, ColliderLayer } from '@dcl/sdk/ecs'
+
+// Local direction raycast
+raycastSystem.registerLocalDirectionRaycast(
+  { entity: myEntity, opts: { queryType: RaycastQueryType.RQT_HIT_FIRST, direction: Vector3.Forward(), maxDistance: 16, collisionMask: ColliderLayer.CL_POINTER } },
+  (result) => {
+    if (result.hits.length > 0) {
+      console.log('Hit:', result.hits[0].entityId)
+    }
+  }
+)
+
+// Global direction raycast
+raycastSystem.registerGlobalDirectionRaycast(
+  { entity: myEntity, opts: { queryType: RaycastQueryType.RQT_HIT_FIRST, direction: Vector3.Down(), maxDistance: 20 } },
+  (result) => { /* handle hits */ }
+)
+
+// Target position raycast
+raycastSystem.registerGlobalTargetRaycast(
+  { entity: myEntity, opts: { globalTarget: Vector3.create(8, 0, 8), maxDistance: 20 } },
+  (result) => { /* handle result */ }
+)
+
+// Target entity raycast
+raycastSystem.registerTargetEntityRaycast(
+  { entity: sourceEntity, opts: { targetEntity: targetEntity, maxDistance: 15 } },
+  (result) => { /* handle result */ }
+)
+
+// Remove raycast from entity
+raycastSystem.removeRaycasterEntity(myEntity)
+```
+
+### Component-Based Raycasting
 
 ```typescript
 import { engine, Raycast, RaycastResult, RaycastQueryType } from '@dcl/sdk/ecs'
@@ -147,6 +232,27 @@ engine.addSystem(() => {
 })
 ```
 
+### Camera Raycast
+
+Cast a ray from the camera to detect what the player is looking at:
+
+```typescript
+raycastSystem.registerGlobalDirectionRaycast(
+  {
+    entity: engine.CameraEntity,
+    opts: {
+      direction: Vector3.rotate(Vector3.Forward(), Transform.get(engine.CameraEntity).rotation),
+      maxDistance: 16
+    }
+  },
+  (result) => {
+    if (result.hits.length > 0) console.log('Looking at:', result.hits[0].entityId)
+  }
+)
+```
+
+---
+
 ## Global Input Handling
 
 Listen for key presses anywhere (not entity-specific):
@@ -164,8 +270,34 @@ engine.addSystem(() => {
   if (inputSystem.isPressed(InputAction.IA_SECONDARY)) {
     console.log('F key is held!')
   }
+
+  // Entity-specific input via system
+  const clickData = inputSystem.getInputCommand(
+    InputAction.IA_POINTER,
+    PointerEventType.PET_DOWN,
+    myEntity
+  )
+  if (clickData) {
+    console.log('Entity clicked via system:', clickData.hit.entityId)
+  }
 })
 ```
+
+## Cursor State
+
+```typescript
+import { PointerLock, PrimaryPointerInfo } from '@dcl/sdk/ecs'
+
+// Check if cursor is locked
+const isLocked = PointerLock.get(engine.CameraEntity).isPointerLocked
+
+// Get cursor position and world ray
+const pointerInfo = PrimaryPointerInfo.get(engine.RootEntity)
+console.log('Cursor position:', pointerInfo.screenCoordinates)
+console.log('World ray direction:', pointerInfo.worldRayDirection)
+```
+
+---
 
 ## Toggle Pattern (Click to Switch States)
 
@@ -186,33 +318,6 @@ pointerEventsSystem.onPointerDown(
 )
 ```
 
-### Raycast System Helpers
-
-Use `raycastSystem` for convenient raycasting without manual component management:
-
-```typescript
-import { raycastSystem, RaycastQueryType, ColliderLayer } from '@dcl/sdk/ecs'
-
-// Register a continuous local-direction raycast
-raycastSystem.registerLocalDirectionRaycast(
-  { entity: myEntity, opts: { queryType: RaycastQueryType.RQT_HIT_FIRST, direction: Vector3.Forward(), maxDistance: 16, collisionMask: ColliderLayer.CL_POINTER } },
-  (result) => {
-    if (result.hits.length > 0) {
-      console.log('Hit:', result.hits[0].entityId)
-    }
-  }
-)
-
-// Register a global-direction raycast
-raycastSystem.registerGlobalDirectionRaycast(
-  { entity: myEntity, opts: { queryType: RaycastQueryType.RQT_HIT_FIRST, direction: Vector3.Down(), maxDistance: 20 } },
-  (result) => { /* handle hits */ }
-)
-
-// Remove raycast from entity
-raycastSystem.removeRaycasterEntity(myEntity)
-```
-
 ## Best Practices
 
 - Always set `maxDistance` on pointer events (8-16m is typical)
@@ -221,3 +326,7 @@ raycastSystem.removeRaycasterEntity(myEntity)
 - Use `MeshCollider` for invisible trigger surfaces
 - For complex interactions, use a system with state tracking
 - Test interactions in preview — hover text should be visible and clear
+- Set `continuous: false` on raycasts unless you need per-frame results
+- Design for both desktop and mobile — mobile has no keyboard, rely on pointer and on-screen buttons
+
+For the full input action list and advanced patterns, see `{baseDir}/references/input-reference.md`.

--- a/skills/add-interactivity/references/input-reference.md
+++ b/skills/add-interactivity/references/input-reference.md
@@ -1,0 +1,148 @@
+# Input System Reference
+
+## All Input Actions
+
+| Action | Key Binding | Constant |
+|--------|-------------|----------|
+| Left mouse button | Mouse click / tap | `InputAction.IA_POINTER` |
+| Primary action | E key | `InputAction.IA_PRIMARY` |
+| Secondary action | F key | `InputAction.IA_SECONDARY` |
+| Action 3 | 1 key | `InputAction.IA_ACTION_3` |
+| Action 4 | 2 key | `InputAction.IA_ACTION_4` |
+| Action 5 | 3 key | `InputAction.IA_ACTION_5` |
+| Action 6 | 4 key | `InputAction.IA_ACTION_6` |
+| Jump | Space key | `InputAction.IA_JUMP` |
+| Forward | W key | `InputAction.IA_FORWARD` |
+| Backward | S key | `InputAction.IA_BACKWARD` |
+| Left | A key | `InputAction.IA_LEFT` |
+| Right | D key | `InputAction.IA_RIGHT` |
+| Walk | Shift key | `InputAction.IA_WALK` |
+
+**Notes:**
+- Mouse wheel is **not available** as an input
+- Always design for both desktop and mobile — mobile has no keyboard, rely on pointer and on-screen buttons
+- Set `maxDistance` on pointer events (8-10 meters typical) to prevent interactions from across the scene
+- Use `hoverText` to communicate what an interaction does before the player commits
+
+## All Pointer Event Types
+
+```typescript
+PointerEventType.PET_DOWN         // Button/key pressed
+PointerEventType.PET_UP           // Button/key released
+PointerEventType.PET_HOVER_ENTER  // Cursor enters entity bounds
+PointerEventType.PET_HOVER_LEAVE  // Cursor leaves entity bounds
+```
+
+## Declarative Pointer Events Component
+
+Instead of the callback system, you can use the `PointerEvents` component directly:
+
+```typescript
+import { PointerEvents, PointerEventType, InputAction } from '@dcl/sdk/ecs'
+
+PointerEvents.create(entity, {
+  pointerEvents: [
+    {
+      eventType: PointerEventType.PET_DOWN,
+      eventInfo: {
+        button: InputAction.IA_POINTER,
+        hoverText: 'Click me',
+        showFeedback: true,
+        maxDistance: 10
+      }
+    }
+  ]
+})
+```
+
+Then read results in a system using `inputSystem.getInputCommand()`.
+
+## Raycast Direction Types
+
+```typescript
+// 1. Local direction — relative to entity rotation
+{ $case: 'localDirection', localDirection: Vector3.Forward() }
+
+// 2. Global direction — world-space direction, ignores entity rotation
+{ $case: 'globalDirection', globalDirection: Vector3.Down() }
+
+// 3. Global target — aim at a specific world position
+{ $case: 'globalTarget', globalTarget: Vector3.create(10, 0, 10) }
+
+// 4. Target entity — aim at another entity dynamically
+{ $case: 'targetEntity', targetEntity: entityId }
+```
+
+### Raycast Options
+
+```typescript
+{
+  direction: Vector3.Forward(),
+  maxDistance: 16,
+  queryType: RaycastQueryType.RQT_HIT_FIRST,  // or RQT_QUERY_ALL
+  originOffset: Vector3.create(0, 0.5, 0),     // offset from entity origin
+  collisionMask: ColliderLayer.CL_PHYSICS | ColliderLayer.CL_CUSTOM1,
+  continuous: false  // true = every frame, false = one-shot
+}
+```
+
+### Camera Raycast
+
+Cast a ray from the camera to detect what the player is looking at:
+
+```typescript
+raycastSystem.registerGlobalDirectionRaycast(
+  {
+    entity: engine.CameraEntity,
+    opts: {
+      direction: Vector3.rotate(Vector3.Forward(), Transform.get(engine.CameraEntity).rotation),
+      maxDistance: 16
+    }
+  },
+  (result) => {
+    if (result.hits.length > 0) console.log('Looking at:', result.hits[0].entityId)
+  }
+)
+```
+
+## Avatar Modifier Areas
+
+Modify how avatars appear or behave in a region:
+
+```typescript
+import { AvatarModifierArea, AvatarModifierType } from '@dcl/sdk/ecs'
+
+AvatarModifierArea.create(entity, {
+  area: { box: Vector3.create(4, 3, 4) },
+  modifiers: [AvatarModifierType.AMT_HIDE_AVATARS],
+  excludeIds: ['0x123...abc']  // Optional
+})
+
+// Available modifiers:
+// AMT_HIDE_AVATARS      — Hide all avatars in the area
+// AMT_DISABLE_PASSPORTS — Disable clicking on avatars to see profiles
+// AMT_DISABLE_JUMPING   — Prevent jumping in the area
+```
+
+## Cursor State
+
+```typescript
+// Check if cursor is locked (pointer lock mode)
+const isLocked = PointerLock.get(engine.CameraEntity).isPointerLocked
+
+// Get cursor position and world ray
+const pointerInfo = PrimaryPointerInfo.get(engine.RootEntity)
+console.log('Cursor screen position:', pointerInfo.screenCoordinates)
+console.log('World ray direction:', pointerInfo.worldRayDirection)
+```
+
+## Trigger Area Callback Fields
+
+The trigger area event callback provides:
+- `triggeredEntity` — the entity that activated the area
+- `eventType` — ENTER, EXIT, or STAY
+- `trigger.entity` — the trigger area entity
+- `trigger.layer` — the collider layer
+- `trigger.position` — position of the triggered entity
+- `trigger.rotation` — rotation of the triggered entity
+- `trigger.scale` — scale of the triggered entity

--- a/skills/advanced-input/SKILL.md
+++ b/skills/advanced-input/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advanced-input
-description: Advanced input handling in Decentraland scenes. Use PointerLock to detect cursor capture state, InputModifier to freeze or restrict player movement, PrimaryPointerInfo for cursor position and world ray, inputSystem.getInputCommand for per-entity input polling, and keyboard patterns for WASD movement controls. Use when user wants custom input, cursor control, movement restriction, keyboard handling, FPS controls, or input polling.
+description: Advanced input handling in Decentraland. PointerLock (cursor capture state), InputModifier (freeze/restrict player movement), PrimaryPointerInfo (cursor position and world ray), WASD keyboard patterns, and action bar slots. Use when the user wants movement restriction, cursor control, FPS controls, input polling, or cutscene freezing. Do NOT use for basic click/hover events on entities (see add-interactivity).
 ---
 
 # Advanced Input Handling in Decentraland

--- a/skills/advanced-rendering/SKILL.md
+++ b/skills/advanced-rendering/SKILL.md
@@ -1,9 +1,25 @@
 ---
 name: advanced-rendering
-description: Advanced rendering features in Decentraland scenes. Use Billboard to make entities face the camera, TextShape for 3D text, advanced PBR material properties like metallic/roughness/transparency, GltfNodeModifiers for per-node visibility and material overrides in GLTF models, and VisibilityComponent to show/hide entities. Use when user wants billboards, 3D text, text labels, material effects, transparency, glow, or model node control.
+description: Advanced rendering in Decentraland scenes. Billboard (face camera), TextShape (3D world text), PBR materials (metallic, roughness, transparency, emissive glow), GltfNodeModifiers (per-node shadow/material overrides), VisibilityComponent (show/hide entities), and texture modes. Use when the user wants billboards, floating labels, 3D text, material effects, glow, transparency, or model node control. Do NOT use for screen-space UI (see build-ui) or loading 3D models (see add-3d-models).
 ---
 
 # Advanced Rendering in Decentraland
+
+## When to Use Which Rendering Feature
+
+| Need | Component | When |
+|------|-----------|------|
+| Entity faces the camera | `Billboard` | Name tags, signs, sprite-like objects |
+| Text in the 3D world | `TextShape` | Labels, signs, floating text above entities |
+| Custom material appearance | `Material.setPbrMaterial` | Metallic, rough, transparent, emissive surfaces |
+| Show/hide without removing | `VisibilityComponent` | LOD systems, toggling objects, conditional display |
+| Modify GLTF model nodes | `GltfNodeModifiers` | Override materials or shadow casting on specific mesh nodes |
+
+**Decision flow:**
+1. Need text on screen? → Use **build-ui** (React-ECS Label) instead
+2. Need text in 3D space? → `TextShape` (+ `Billboard` to face camera)
+3. Need glowing/transparent materials? → `Material.setPbrMaterial` with emissive/transparency
+4. Need to override material on a model node? → `GltfNodeModifiers` with `modifiers` array
 
 ## Billboard (Face the Camera)
 
@@ -212,20 +228,20 @@ function lodSystem() {
 engine.addSystem(lodSystem)
 ```
 
-### Per-Node Material Overrides (GltfNodeModifiers)
+### Per-Node Modifiers (GltfNodeModifiers)
 
-Override materials on specific nodes within a GLTF model without modifying the model file:
+Override material or shadow casting on specific nodes within a GLTF model:
 
 ```typescript
-import { GltfNode, GltfNodeState } from '@dcl/sdk/ecs'
+import { GltfNodeModifiers } from '@dcl/sdk/ecs'
 
-// Hide a specific node in a model
-GltfNode.create(entity, { path: 'RootNode/Armor', visible: false })
-
-// Override a node's material
-GltfNode.create(entity, {
-  path: 'RootNode/Helmet',
-  materialOverride: Material.Texture.Common({ src: 'images/custom-skin.png' })
+GltfNodeModifiers.create(entity, {
+  modifiers: [
+    {
+      path: 'RootNode/Armor',     // GLTF hierarchy path
+      castShadows: false           // Disable shadow casting for this node
+    }
+  ]
 })
 ```
 

--- a/skills/animations-tweens/SKILL.md
+++ b/skills/animations-tweens/SKILL.md
@@ -1,9 +1,23 @@
 ---
 name: animations-tweens
-description: Animate objects in Decentraland scenes using Animator (GLTF animations), Tween (move/rotate/scale over time), and TweenSequence (chain animations). Use when user wants to animate, move, rotate, spin, slide, or create motion effects.
+description: Animate objects in Decentraland scenes. Play GLTF model animations with Animator, create procedural motion with Tween (move/rotate/scale), and chain sequences with TweenSequence. Use when the user wants to animate, move, rotate, spin, slide, bob, or create motion effects. Do NOT use for audio/video playback (see audio-video).
 ---
 
 # Animations and Tweens in Decentraland
+
+## When to Use Which Animation Approach
+
+| Need | Approach | When |
+|------|----------|------|
+| Play animation baked into a .glb model | `Animator` | Character walks, door opens, flag waves — any animation created in Blender/Maya |
+| Move/rotate/scale an entity smoothly | `Tween` | Sliding doors, floating platforms, growing objects — procedural A-to-B motion |
+| Chain multiple animations in sequence | `TweenSequence` | Patrol paths, multi-step doors, complex choreography |
+| Continuous per-frame control | `engine.addSystem()` | Physics-like motion, following a target, custom easing |
+
+**Decision flow:**
+1. Does the .glb model already have the animation? → `Animator`
+2. Is it a simple move/rotate/scale between two values? → `Tween`
+3. Do you need frame-by-frame control or custom math? → System with `dt`
 
 ## GLTF Animations (Animator)
 
@@ -67,7 +81,7 @@ Tween.create(box, {
     end: Vector3.create(14, 1, 8)
   }),
   duration: 2000,  // milliseconds
-  easingFunction: EasingFunction.EF_EASEINOUTSINE
+  easingFunction: EasingFunction.EF_EASESINE
 })
 ```
 
@@ -100,7 +114,7 @@ Tween.create(box, {
 Chain multiple tweens to play one after another:
 
 ```typescript
-import { TweenSequence } from '@dcl/sdk/ecs'
+import { TweenSequence, TweenLoop } from '@dcl/sdk/ecs'
 
 // First tween
 Tween.create(box, {
@@ -109,7 +123,7 @@ Tween.create(box, {
     end: Vector3.create(14, 1, 8)
   }),
   duration: 2000,
-  easingFunction: EasingFunction.EF_EASEINOUTSINE
+  easingFunction: EasingFunction.EF_EASESINE
 })
 
 // Chain sequence
@@ -122,7 +136,7 @@ TweenSequence.create(box, {
         end: Vector3.create(2, 1, 8)
       }),
       duration: 2000,
-      easingFunction: EasingFunction.EF_EASEINOUTSINE
+      easingFunction: EasingFunction.EF_EASESINE
     }
   ],
   loop: TweenLoop.TL_RESTART // Loop the entire sequence
@@ -133,12 +147,16 @@ TweenSequence.create(box, {
 
 Available easing functions from `EasingFunction`:
 - `EF_LINEAR` — Constant speed
-- `EF_EASEINQUAD` / `EF_EASEOUTQUAD` / `EF_EASEINOUTQUAD` — Quadratic
-- `EF_EASEINSINE` / `EF_EASEOUTSINE` / `EF_EASEINOUTSINE` — Sinusoidal (smooth)
-- `EF_EASEINEXPO` / `EF_EASEOUTEXPO` / `EF_EASEINOUTEXPO` — Exponential
-- `EF_EASEINELASTIC` / `EF_EASEOUTELASTIC` / `EF_EASEINOUTELASTIC` — Elastic bounce
-- `EF_EASEOUTBOUNCE` / `EF_EASEINBOUNCE` / `EF_EASEINOUTBOUNCE` — Bounce effect
-- `EF_EASEINBACK` / `EF_EASEOUTBACK` / `EF_EASEINOUTBACK` — Overshoot
+- `EF_EASEINQUAD` / `EF_EASEOUTQUAD` / `EF_EASEQUAD` — Quadratic
+- `EF_EASEINSINE` / `EF_EASEOUTSINE` / `EF_EASESINE` — Sinusoidal (smooth)
+- `EF_EASEINEXPO` / `EF_EASEOUTEXPO` / `EF_EASEEXPO` — Exponential
+- `EF_EASEINELASTIC` / `EF_EASEOUTELASTIC` / `EF_EASEELASTIC` — Elastic bounce
+- `EF_EASEOUTBOUNCE` / `EF_EASEINBOUNCE` / `EF_EASEBOUNCE` — Bounce effect
+- `EF_EASEINBACK` / `EF_EASEOUTBACK` / `EF_EASEBACK` — Overshoot
+- `EF_EASEINCUBIC` / `EF_EASEOUTCUBIC` / `EF_EASECUBIC` — Cubic
+- `EF_EASEINQUART` / `EF_EASEOUTQUART` / `EF_EASEQUART` — Quartic
+- `EF_EASEINQUINT` / `EF_EASEOUTQUINT` / `EF_EASEQUINT` — Quintic
+- `EF_EASEINCIRC` / `EF_EASEOUTCIRC` / `EF_EASECIRC` — Circular
 
 ## Custom Animation Systems
 
@@ -165,28 +183,28 @@ engine.addSystem(spinSystem)
 
 ### Tween Helper Methods
 
-Use shorthand helpers instead of creating Tween components manually:
+Use shorthand helpers that create or replace the Tween component directly on the entity:
 
 ```typescript
 import { Tween, EasingFunction } from '@dcl/sdk/ecs'
 
-// Move
-Tween.createOrReplace(entity, Tween.setMove(
+// Move — signature: Tween.setMove(entity, start, end, duration, easingFunction?)
+Tween.setMove(entity,
   Vector3.create(0, 1, 0), Vector3.create(0, 3, 0),
-  { duration: 1500, easingFunction: EasingFunction.EF_EASEINBOUNCE }
-))
+  1500, EasingFunction.EF_EASEINBOUNCE
+)
 
-// Rotate
-Tween.createOrReplace(entity, Tween.setRotate(
+// Rotate — signature: Tween.setRotate(entity, start, end, duration, easingFunction?)
+Tween.setRotate(entity,
   Quaternion.fromEulerDegrees(0, 0, 0), Quaternion.fromEulerDegrees(0, 180, 0),
-  { duration: 2000, easingFunction: EasingFunction.EF_EASEOUTQUAD }
-))
+  2000, EasingFunction.EF_EASEOUTQUAD
+)
 
-// Scale
-Tween.createOrReplace(entity, Tween.setScale(
+// Scale — signature: Tween.setScale(entity, start, end, duration, easingFunction?)
+Tween.setScale(entity,
   Vector3.One(), Vector3.create(2, 2, 2),
-  { duration: 1000, easingFunction: EasingFunction.EF_LINEAR }
-))
+  1000, EasingFunction.EF_LINEAR
+)
 ```
 
 ### Yoyo Loop Mode
@@ -228,6 +246,18 @@ const anim = Animator.getMutable(entity)
 anim.states[0].weight = 0.5  // blend walk at 50%
 anim.states[1].weight = 0.5  // blend idle at 50%
 ```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| GLTF animation not playing | Wrong clip name in `Animator.states` | Open the .glb in a viewer (e.g., Blender) to find exact clip names — they are case-sensitive |
+| Animator component has no effect | Entity missing `GltfContainer` | `Animator` only works on entities that have a loaded GLTF model |
+| Tween doesn't move | Start and end positions are the same | Verify `start` and `end` values differ in `Tween.Mode.Move()` |
+| Tween plays once then stops | No `TweenSequence` with loop | Add `TweenSequence.create(entity, { sequence: [], loop: TweenLoop.TL_YOYO })` for back-and-forth |
+| Animation jitters or stutters | Creating new Tween every frame | Only create Tween once, not inside a system — use `tweenSystem.tweenCompleted()` to chain |
+
+> **Need 3D models to animate?** See the **add-3d-models** skill for loading GLTF models that contain animation clips.
 
 ## Best Practices
 

--- a/skills/audio-video/SKILL.md
+++ b/skills/audio-video/SKILL.md
@@ -1,9 +1,22 @@
 ---
 name: audio-video
-description: Add audio sources, sound effects, music, audio streaming, and video players to Decentraland scenes. Use when user wants sound, music, audio, video screens, speakers, or media playback.
+description: Add sound effects, music, audio streaming, and video players to Decentraland scenes. Covers AudioSource (local files), AudioStream (streaming URLs), VideoPlayer (video surfaces), video events, and media permissions. Use when the user wants sound, music, audio, video screens, radio, or media playback. Do NOT use for 3D model animations (see animations-tweens).
 ---
 
 # Audio and Video in Decentraland
+
+## When to Use Which Media Component
+
+| Need | Component | Key Difference |
+|------|-----------|---------------|
+| Sound effect from a file (click, explosion, footstep) | `AudioSource` | Local file, spatial, one-shot or looping |
+| Background music or radio stream | `AudioStream` | External URL, non-spatial, continuous |
+| Video on a surface (screen, billboard) | `VideoPlayer` + `Material.Texture.Video` | Requires a mesh to display on |
+
+**Decision flow:**
+1. Is it a local audio file? → `AudioSource`
+2. Is it a streaming URL (radio, live audio)? → `AudioStream`
+3. Is it video content? → `VideoPlayer` on a plane/mesh
 
 ## Audio Source (Sound Effects & Music)
 
@@ -288,6 +301,8 @@ Material.setPbrMaterial(screen2, {
 - **Distance-based control**: Pause video when player is far away to save bandwidth
 - **Supported formats**: `.mp4` (H.264), `.webm`, HLS (`.m3u8`) for live streaming
 - **Live streaming**: Use HLS (`.m3u8`) URLs — most reliable across clients
+
+For full component field details, supported formats, and advanced patterns, see `{baseDir}/references/media-reference.md`.
 
 ## Important Notes
 

--- a/skills/audio-video/references/media-reference.md
+++ b/skills/audio-video/references/media-reference.md
@@ -1,0 +1,184 @@
+# Media Components Reference
+
+## AudioSource — Full Fields
+
+```typescript
+import { AudioSource } from '@dcl/sdk/ecs'
+
+AudioSource.create(entity, {
+  audioClipUrl: 'sounds/effect.mp3',  // Path to local audio file (required)
+  playing: false,                      // Start/stop playback
+  loop: false,                         // Loop when finished
+  volume: 1.0,                         // Volume 0.0 to 1.0
+  pitch: 1.0                           // Playback speed (0.5 = half, 2.0 = double)
+})
+```
+
+**Supported formats:** `.mp3` (recommended), `.ogg`, `.wav`
+
+Audio is spatial by default — volume decreases with distance from the entity. Place the entity where the sound should originate.
+
+### Playback Control
+
+```typescript
+const audio = AudioSource.getMutable(entity)
+audio.playing = true   // Play
+audio.playing = false  // Stop
+audio.volume = 0.5     // Adjust volume
+audio.pitch = 1.5      // Speed up
+```
+
+### Reset and Replay
+
+To replay a sound effect from the beginning:
+```typescript
+const audio = AudioSource.getMutable(entity)
+audio.playing = false
+audio.playing = true  // Restarts from beginning
+```
+
+## AudioStream — Full Fields
+
+```typescript
+import { AudioStream } from '@dcl/sdk/ecs'
+
+AudioStream.create(entity, {
+  url: 'https://stream.example.com/radio.mp3',  // Streaming URL (required)
+  playing: true,                                   // Start/stop stream
+  volume: 0.5                                      // Volume 0.0 to 1.0
+})
+```
+
+**Supported stream formats:** HTTP/HTTPS audio streams (`.mp3`, `.ogg`, `.aac`)
+
+AudioStream is NOT spatial — it plays at the same volume regardless of player distance. Best for background music or radio.
+
+## VideoPlayer — Full Fields
+
+```typescript
+import { VideoPlayer } from '@dcl/sdk/ecs'
+
+VideoPlayer.create(entity, {
+  src: 'videos/clip.mp4',    // Local file or external URL (required)
+  playing: true,              // Start/stop playback
+  loop: false,                // Loop when finished
+  volume: 1.0,                // Volume 0.0 to 1.0
+  playbackRate: 1.0,          // Playback speed
+  position: 0                 // Start time in seconds
+})
+```
+
+**Supported formats:**
+- `.mp4` (H.264) — most compatible
+- `.webm` — good quality, smaller files
+- `.ogg` — open format
+- `.m3u8` (HLS) — live streaming, most reliable for streams
+
+### Video Texture Setup
+
+VideoPlayer alone doesn't display video. You must create a video texture and apply it to a mesh:
+
+```typescript
+// 1. Create mesh surface
+MeshRenderer.setPlane(entity)
+
+// 2. Create video texture referencing the VideoPlayer entity
+const videoTexture = Material.Texture.Video({ videoPlayerEntity: entity })
+
+// 3. Apply as basic material (best performance)
+Material.setBasicMaterial(entity, { texture: videoTexture })
+
+// OR as PBR material with emissive (self-lit screen)
+Material.setPbrMaterial(entity, {
+  texture: videoTexture,
+  roughness: 1.0,
+  specularIntensity: 0,
+  metallic: 0,
+  emissiveTexture: videoTexture,
+  emissiveIntensity: 0.6,
+  emissiveColor: Color3.White()
+})
+```
+
+### Live Streaming
+
+```typescript
+// HLS stream
+VideoPlayer.create(entity, {
+  src: 'https://example.com/stream.m3u8',
+  playing: true
+})
+
+// LiveKit video stream
+VideoPlayer.create(entity, {
+  src: 'livekit-video://current-stream',
+  playing: true
+})
+```
+
+### Video Events
+
+```typescript
+import { videoEventsSystem, VideoState } from '@dcl/sdk/ecs'
+
+videoEventsSystem.registerVideoEventsEntity(entity, (event) => {
+  console.log('State:', event.state)          // VideoState enum
+  console.log('Time:', event.currentOffset)   // Current playback time
+  console.log('Length:', event.videoLength)    // Total duration
+})
+
+// Poll current state
+const state = videoEventsSystem.getVideoState(entity)
+```
+
+**VideoState values:** `VS_READY`, `VS_PLAYING`, `VS_PAUSED`, `VS_ERROR`, `VS_BUFFERING`, `VS_SEEKING`, `VS_NONE`
+
+### Multiple Screens, One Video
+
+```typescript
+// One VideoPlayer, shared across screens
+VideoPlayer.create(screen1, { src: 'videos/shared.mp4', playing: true })
+const tex = Material.Texture.Video({ videoPlayerEntity: screen1 })
+Material.setBasicMaterial(screen1, { texture: tex })
+Material.setBasicMaterial(screen2, { texture: tex })
+```
+
+### Video Limits
+
+| Quality Setting | Max Simultaneous Videos |
+|----------------|------------------------|
+| Low | 1 |
+| Medium | 5 |
+| High | 10 |
+
+### Media Permissions in scene.json
+
+External audio/video URLs require permissions:
+
+```json
+{
+  "requiredPermissions": ["ALLOW_MEDIA_HOSTNAMES"],
+  "allowedMediaHostnames": ["stream.example.com", "cdn.example.com"]
+}
+```
+
+## AudioAnalysis (Advanced)
+
+Real-time frequency and amplitude data from audio sources:
+
+```typescript
+import { AudioAnalysis, AudioAnalysisView } from '@dcl/sdk/ecs'
+
+// Enable analysis on an audio source entity
+AudioAnalysis.create(audioEntity, {})
+
+// Read analysis data in a system
+engine.addSystem(() => {
+  const view = AudioAnalysisView.getOrNull(audioEntity)
+  if (view) {
+    // Use frequency/amplitude data for visualizers, beat detection, etc.
+  }
+})
+```
+
+Used for music visualizers, reactive environments, and beat-synced animations.

--- a/skills/authoritative-server/SKILL.md
+++ b/skills/authoritative-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: authoritative-server
-description: Build multiplayer scenes with a headless authoritative server that controls game state, validates changes, and prevents cheating. Install @dcl/sdk@auth-server and run with hammurabi-server. Use isServer() to branch logic, registerMessages() for client-server communication, validateBeforeChange() for server-only components, Storage for persistence, and EnvVar for configuration. Use when user wants authoritative server, anti-cheat, server-side validation, persistent storage, environment variables, or server messages.
+description: Build multiplayer Decentraland scenes with a headless authoritative server. Covers isServer() branching, registerMessages() for client-server communication, validateBeforeChange() for server-only state, Storage (world and player persistence), EnvVar (environment variables), and project structure. Use when the user wants authoritative multiplayer, anti-cheat, server-side validation, persistent storage, or server messages. Do NOT use for basic CRDT multiplayer without a server (see multiplayer-sync).
 ---
 
 # Authoritative Server Pattern
@@ -181,10 +181,10 @@ room.onMessage('gameEvent', (data) => {
 Before sending messages from the client, wait until state is synchronized:
 
 ```typescript
-import { isStateSynchronized } from '@dcl/sdk/network'
+import { isStateSyncronized } from '@dcl/sdk/network'
 
 engine.addSystem(() => {
-  if (!isStateSynchronized()) return
+  if (!isStateSyncronized()) return
 
   // Safe to send messages now
   room.send('playerJoin', { displayName: 'Player' })
@@ -323,10 +323,12 @@ Put synced components and messages in `shared/` so both server and client import
 ## Important Notes
 
 - **Use `Schemas.Int64` for timestamps**: `Schemas.Number` corrupts large numbers (13+ digits). Always use `Schemas.Int64` for values like `Date.now()`.
-- **State sync readiness**: Clients must wait for `isStateSynchronized()` (from `@dcl/sdk/network`) to return `true` before sending messages.
+- **State sync readiness**: Clients must wait for `isStateSyncronized()` (from `@dcl/sdk/network`) to return `true` before sending messages. Note the intentional SDK typo: "Syncronized" not "Synchronized".
 - **Custom vs built-in validation**: Custom components use global `validateBeforeChange((value) => ...)`. Built-in components (Transform, GltfContainer) use per-entity `validateBeforeChange(entity, (value) => ...)`.
 - **Single codebase**: Both server and client run the same `index.ts` entry point. Use `isServer()` to branch.
 - **No Node.js APIs**: The DCL runtime uses sandboxed QuickJS — no `fs`, `http`, etc. `setTimeout`/`setInterval` are supported. Use SDK-provided APIs (Storage, EnvVar, engine systems) for server-side operations.
 - **SDK branch (MANDATORY)**: The auth-server pattern requires `npm install @dcl/sdk@auth-server`, not the standard `@dcl/sdk`. Without it, `isServer()`, `registerMessages()`, `Storage`, and `EnvVar` are unavailable.
 - **scene.json required fields**: `authoritativeMultiplayer: true` must be set, and `logsPermissions: ["0xWalletAddress"]` must list wallet addresses that should see server logs.
 - For basic CRDT multiplayer without a server, see the `multiplayer-sync` skill.
+
+For complete server setup examples, authentication flow, state reconciliation, Storage patterns, and EnvVar usage, see `{baseDir}/references/server-patterns.md`.

--- a/skills/authoritative-server/references/server-patterns.md
+++ b/skills/authoritative-server/references/server-patterns.md
@@ -1,0 +1,251 @@
+# Authoritative Server Patterns Reference
+
+## Complete Server Setup
+
+### Project Structure
+
+```
+src/
+├── index.ts              # Entry point — isServer() branching
+├── client/
+│   ├── setup.ts          # Client init, input handlers, message senders
+│   └── ui.tsx            # React ECS UI (reads synced state, sends messages)
+├── server/
+│   ├── server.ts         # Server init, game loop, message handlers
+│   └── gameState.ts      # Server state management
+└── shared/
+    ├── schemas.ts        # Custom component definitions + validateBeforeChange
+    └── messages.ts       # Message definitions via registerMessages()
+```
+
+### Entry Point (index.ts)
+
+```typescript
+import { isServer } from '@dcl/sdk/network'
+
+export async function main() {
+  if (isServer()) {
+    const { initServer } = await import('./server/server')
+    initServer()
+    return
+  }
+
+  const { initClient } = await import('./client/setup')
+  const { setupUi } = await import('./client/ui')
+  initClient()
+  setupUi()
+}
+```
+
+### Shared Schemas (shared/schemas.ts)
+
+```typescript
+import { engine, Schemas, Entity } from '@dcl/sdk/ecs'
+import { AUTH_SERVER_PEER_ID } from '@dcl/sdk/network/message-bus-sync'
+
+// Custom synced component
+export const GameState = engine.defineComponent('game:State', {
+  phase: Schemas.String,
+  score: Schemas.Int,
+  timeRemaining: Schemas.Int
+})
+
+// Global validation — only server can modify
+GameState.validateBeforeChange((value) => {
+  return value.senderAddress === AUTH_SERVER_PEER_ID
+})
+
+// For built-in components, use per-entity validation
+type ComponentWithValidation = {
+  validateBeforeChange: (entity: Entity, cb: (value: { senderAddress: string }) => boolean) => void
+}
+
+export function protectServerEntity(entity: Entity, components: ComponentWithValidation[]) {
+  for (const component of components) {
+    component.validateBeforeChange(entity, (value) => {
+      return value.senderAddress === AUTH_SERVER_PEER_ID
+    })
+  }
+}
+```
+
+### Shared Messages (shared/messages.ts)
+
+```typescript
+import { Schemas } from '@dcl/sdk/ecs'
+import { registerMessages } from '@dcl/sdk/network'
+
+export const Messages = {
+  // Client → Server
+  playerReady: Schemas.Map({ displayName: Schemas.String }),
+  playerAction: Schemas.Map({ action: Schemas.String, targetId: Schemas.Int }),
+
+  // Server → Client
+  gameStarted: Schemas.Map({ roundNumber: Schemas.Int }),
+  playerScored: Schemas.Map({ playerName: Schemas.String, points: Schemas.Int }),
+  gameEnded: Schemas.Map({ winnerId: Schemas.String })
+}
+
+export const room = registerMessages(Messages)
+```
+
+### Server Logic (server/server.ts)
+
+```typescript
+import { engine, PlayerIdentityData, Transform } from '@dcl/sdk/ecs'
+import { syncEntity } from '@dcl/sdk/network'
+import { room } from '../shared/messages'
+import { GameState, protectServerEntity } from '../shared/schemas'
+
+export function initServer() {
+  // Create server-managed entities
+  const stateEntity = engine.addEntity()
+  GameState.create(stateEntity, { phase: 'lobby', score: 0, timeRemaining: 60 })
+  protectServerEntity(stateEntity, [Transform])
+  syncEntity(stateEntity, [GameState.componentId], 1)
+
+  // Handle client messages
+  room.onMessage('playerReady', (data, context) => {
+    if (!context) return
+    console.log(`[Server] ${data.displayName} ready (${context.from})`)
+  })
+
+  room.onMessage('playerAction', (data, context) => {
+    if (!context) return
+    // Validate action on server
+    const playerPos = getPlayerPosition(context.from)
+    if (isValidAction(data.action, playerPos)) {
+      applyAction(data)
+    }
+  })
+
+  // Game loop
+  engine.addSystem(gameLoopSystem)
+}
+```
+
+## Authentication Flow
+
+The auth server automatically provides player identity via `PlayerIdentityData`:
+
+```typescript
+// Server reads actual player positions
+engine.addSystem(() => {
+  for (const [entity, identity] of engine.getEntitiesWith(PlayerIdentityData)) {
+    const transform = Transform.getOrNull(entity)
+    if (!transform) continue
+
+    // identity.address = wallet address (verified by server)
+    // transform.position = actual player position (not client-reported)
+    console.log(`[Server] ${identity.address} at`, transform.position)
+  }
+})
+```
+
+Never trust client-reported positions. The server sees real positions via `PlayerIdentityData` + `Transform`.
+
+## State Reconciliation
+
+When server state diverges from client state, the server always wins:
+
+```typescript
+// Server-side: apply authoritative state
+function reconcileState() {
+  const state = GameState.getMutable(stateEntity)
+
+  // Server calculates correct state
+  state.timeRemaining = Math.max(0, state.timeRemaining - 1)
+
+  if (state.timeRemaining <= 0 && state.phase === 'active') {
+    state.phase = 'ended'
+    room.send('gameEnded', { winnerId: findWinner() })
+  }
+}
+```
+
+Because `validateBeforeChange` blocks client writes, clients can only read the state and send messages. The server is the single source of truth.
+
+## Storage Patterns
+
+### World Storage (Global Data)
+
+```typescript
+import { Storage } from '@dcl/sdk/server'
+
+// Save leaderboard
+await Storage.world.set('leaderboard', JSON.stringify([
+  { name: 'Alice', score: 100 },
+  { name: 'Bob', score: 85 }
+]))
+
+// Load leaderboard
+const data = await Storage.world.get<string>('leaderboard')
+const leaderboard = data ? JSON.parse(data) : []
+
+// Delete
+await Storage.world.delete('leaderboard')
+```
+
+### Player Storage (Per-Player Data)
+
+```typescript
+import { Storage } from '@dcl/sdk/server'
+
+// Save player progress
+await Storage.player.set(playerAddress, 'progress', JSON.stringify({
+  level: 5,
+  coins: 250,
+  achievements: ['first_kill', 'speedrun']
+}))
+
+// Load player progress
+const saved = await Storage.player.get<string>(playerAddress, 'progress')
+const progress = saved ? JSON.parse(saved) : { level: 1, coins: 0, achievements: [] }
+```
+
+**Note:** Storage only accepts strings. Always `JSON.stringify()` objects and `String()` numbers.
+
+**Local dev storage location:** `node_modules/@dcl/sdk-commands/.runtime-data/server-storage.json`
+
+## Environment Variables
+
+```typescript
+import { EnvVar } from '@dcl/sdk/server'
+
+// Read with defaults
+const maxPlayers = parseInt((await EnvVar.get('MAX_PLAYERS')) || '4')
+const gameDuration = parseInt((await EnvVar.get('GAME_DURATION')) || '300')
+const debugMode = ((await EnvVar.get('DEBUG')) || 'false') === 'true'
+```
+
+### Local Development (.env file)
+
+```
+MAX_PLAYERS=8
+GAME_DURATION=300
+DEBUG=true
+```
+
+### Production Deployment
+
+```bash
+npx sdk-commands deploy-env MAX_PLAYERS --value 8
+npx sdk-commands deploy-env GAME_DURATION --value 300
+npx sdk-commands deploy-env OLD_VAR --delete
+```
+
+## scene.json Required Fields
+
+```json
+{
+  "authoritativeMultiplayer": true,
+  "worldConfiguration": {
+    "name": "my-world.dcl.eth"
+  },
+  "logsPermissions": ["0xYourWalletAddress"]
+}
+```
+
+- `authoritativeMultiplayer: true` — enables the headless server runtime
+- `worldConfiguration.name` — identifies the world (required for Storage and deploy)
+- `logsPermissions` — wallet addresses that can see `console.log()` from the server

--- a/skills/build-ui/SKILL.md
+++ b/skills/build-ui/SKILL.md
@@ -1,11 +1,22 @@
 ---
 name: build-ui
-description: Build 2D user interfaces for Decentraland scenes using React-ECS. Create HUDs, menus, health bars, scoreboards, dialogs, buttons, and input forms. Use when user wants to add UI, HUD, buttons, text overlays, menus, or on-screen elements.
+description: Build 2D screen-space UI for Decentraland scenes using React-ECS (JSX). Create HUDs, menus, health bars, scoreboards, dialogs, buttons, inputs, and dropdowns. Use when the user wants screen overlays, on-screen UI, HUD elements, menus, or form inputs. Do NOT use for 3D in-world text (see advanced-rendering) or clickable 3D objects (see add-interactivity).
 ---
 
 # Building UI with React-ECS
 
 Decentraland SDK7 uses a React-like JSX system for 2D UI overlays.
+
+## When to Use Which UI Approach
+
+| Need | Approach | Component |
+|------|----------|-----------|
+| Screen-space HUD, menus, buttons | React-ECS (this skill) | `UiEntity`, `Label`, `Button`, `Input`, `Dropdown` |
+| 3D text floating in the world | TextShape + Billboard | See **advanced-rendering** skill |
+| Open a web page | `openExternalUrl` | See **scene-runtime** skill |
+| Clickable objects in 3D space | Pointer events | See **add-interactivity** skill |
+
+Use React-ECS for any 2D overlay: scoreboards, health bars, dialogs, inventories, settings menus. Use TextShape for labels above NPCs or objects in the 3D world.
 
 ## Setup
 
@@ -293,6 +304,19 @@ The `Dropdown` component supports additional props:
 />
 ```
 
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| UI not appearing at all | Missing `ReactEcsRenderer.setUiRenderer()` call | Add `ReactEcsRenderer.setUiRenderer(MyUI)` in `main()` or `setupUi()` |
+| UI elements overlapping | Missing `flexDirection` or wrong layout | Set `flexDirection: 'column'` on the parent container |
+| Button clicks not registering | Missing `onMouseDown` handler | Add `onMouseDown={() => { ... }}` to the Button or UiEntity |
+| JSX errors at compile time | File extension is `.ts` instead of `.tsx` | Rename the file to `.tsx` |
+| Multiple UIs fighting | More than one `setUiRenderer` call | Only call `setUiRenderer` once — combine all UI into a single root component |
+| Text not visible | Text color matches background | Set contrasting `color` on Label or `uiText` |
+
+> **World interactions instead of screen UI?** See the **add-interactivity** skill for click handlers and pointer events on 3D objects.
+
 ## Important Notes
 
 - React hooks (`useState`, `useEffect`, etc.) are **NOT** available — use module-level variables
@@ -301,3 +325,5 @@ The `Dropdown` component supports additional props:
 - Use `display: 'none'` in `uiTransform` to hide elements without removing them
 - File extension must be `.tsx` for JSX support
 - Only one `ReactEcsRenderer.setUiRenderer()` call per scene — combine all UI into one root component
+
+For full component props (UiEntity, Label, Button, Input, Dropdown), layout patterns, and responsive design, see `{baseDir}/references/ui-components.md`.

--- a/skills/build-ui/references/ui-components.md
+++ b/skills/build-ui/references/ui-components.md
@@ -1,0 +1,228 @@
+# UI Components Reference — React ECS
+
+## Setup
+
+```typescript
+// ui.tsx
+import ReactEcs, { ReactEcsRenderer, UiEntity, Label, Button, Input, Dropdown } from '@dcl/sdk/react-ecs'
+
+export function setupUi() {
+  ReactEcsRenderer.setUiRenderer(MyUI)
+}
+```
+
+Only call `ReactEcsRenderer.setUiRenderer()` once per scene. Combine all UI into a single root component.
+
+## UiEntity — All Props
+
+```tsx
+<UiEntity
+  uiTransform={{
+    // Size
+    width: 300,                  // Pixels or '50%'
+    height: 200,
+    minWidth: 100,
+    maxWidth: 500,
+    minHeight: 50,
+    maxHeight: 400,
+
+    // Position
+    positionType: 'absolute',    // 'absolute' | 'relative' (default)
+    position: { top: 10, right: 10, bottom: 10, left: 10 },
+
+    // Display
+    display: 'flex',             // 'flex' | 'none'
+
+    // Flexbox
+    flexDirection: 'column',     // 'row' | 'column'
+    justifyContent: 'center',    // 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around'
+    alignItems: 'center',        // 'flex-start' | 'center' | 'flex-end' | 'stretch'
+    flexWrap: 'wrap',            // 'nowrap' | 'wrap'
+
+    // Spacing
+    padding: { top: 10, bottom: 10, left: 10, right: 10 },  // or single number
+    margin: { top: 5, bottom: 5, left: 5, right: 5 }        // or single number
+  }}
+
+  uiBackground={{
+    color: Color4.create(0, 0, 0, 0.8),           // Solid color
+    texture: { src: 'images/bg.png' },             // Image
+    textureMode: 'stretch',                         // 'stretch' | 'nine-slices' | 'center'
+    textureSlices: { top: 0.1, bottom: 0.1, left: 0.1, right: 0.1 },  // For nine-slices
+    avatarTexture: { userId: 'user-id' }           // Avatar portrait
+  }}
+
+  uiText={{
+    value: 'Hello!',
+    fontSize: 18,
+    color: Color4.White(),
+    textAlign: 'middle-center',
+    font: 'sans-serif',          // 'sans-serif' | 'serif' | 'monospace'
+    fontWeight: 'bold'           // 'normal' | 'bold'
+  }}
+
+  // Events
+  onMouseDown={() => { }}
+  onMouseUp={() => { }}
+  onMouseEnter={() => { }}
+  onMouseLeave={() => { }}
+/>
+```
+
+## Label
+
+```tsx
+<Label
+  value="Score: 100"
+  fontSize={18}
+  color={Color4.White()}
+  textAlign="middle-center"
+  font="serif"
+  uiTransform={{ width: 200, height: 30 }}
+/>
+```
+
+**textAlign values:** `top-left`, `top-center`, `top-right`, `middle-left`, `middle-center`, `middle-right`, `bottom-left`, `bottom-center`, `bottom-right`
+
+**font values:** `sans-serif` (default), `serif`, `monospace`
+
+## Button
+
+```tsx
+<Button
+  value="Click Me"
+  variant="primary"           // 'primary' | 'secondary'
+  fontSize={16}
+  color={Color4.White()}      // Text color
+  uiTransform={{ width: 150, height: 40 }}
+  uiBackground={{ color: Color4.Blue() }}  // Override default style
+  onMouseDown={() => { console.log('clicked') }}
+/>
+```
+
+## Input
+
+```tsx
+<Input
+  placeholder="Enter text..."
+  placeholderColor={Color4.Gray()}
+  color={Color4.Black()}
+  fontSize={16}
+  uiTransform={{ width: 250, height: 40 }}
+  onChange={(value) => { console.log('Changing:', value) }}
+  onSubmit={(value) => { console.log('Submitted:', value) }}
+/>
+```
+
+## Dropdown
+
+```tsx
+<Dropdown
+  options={['Option A', 'Option B', 'Option C']}
+  selectedIndex={0}
+  onChange={(index) => { console.log('Selected:', index) }}
+  fontSize={14}
+  color={Color4.Black()}
+  uiTransform={{ width: 200, height: 40 }}
+  acceptEmpty={true}
+  emptyLabel="-- Select --"
+  disabled={false}
+/>
+```
+
+## Layout Patterns
+
+### Health Bar
+
+```tsx
+<UiEntity
+  uiTransform={{ width: 200, height: 20, positionType: 'absolute', position: { bottom: 20, left: '50%' } }}
+  uiBackground={{ color: Color4.create(0.3, 0.3, 0.3, 0.8) }}
+>
+  <UiEntity
+    uiTransform={{ width: `${health}%`, height: '100%' }}
+    uiBackground={{ color: Color4.create(0.2, 0.8, 0.2, 1) }}
+  />
+</UiEntity>
+```
+
+### Modal Dialog
+
+```tsx
+const Modal = () => {
+  if (!isOpen) return null
+  return (
+    <UiEntity
+      uiTransform={{ width: '100%', height: '100%', positionType: 'absolute', alignItems: 'center', justifyContent: 'center' }}
+      uiBackground={{ color: Color4.create(0, 0, 0, 0.5) }}
+    >
+      <UiEntity
+        uiTransform={{ width: 400, height: 300, flexDirection: 'column', alignItems: 'center', padding: 20 }}
+        uiBackground={{ color: Color4.create(0.2, 0.2, 0.2, 1) }}
+      >
+        <Label value="Title" fontSize={24} />
+        <Button value="Close" variant="primary" onMouseDown={() => { isOpen = false }} uiTransform={{ width: 100, height: 40 }} />
+      </UiEntity>
+    </UiEntity>
+  )
+}
+```
+
+### Inventory Grid
+
+```tsx
+<UiEntity uiTransform={{ width: 350, flexDirection: 'row', flexWrap: 'wrap' }}>
+  {items.map((item, i) => (
+    <UiEntity
+      key={i}
+      uiTransform={{ width: 70, height: 70, margin: 5, alignItems: 'center', justifyContent: 'center' }}
+      uiBackground={{ color: Color4.create(0.3, 0.3, 0.3, 1) }}
+      uiText={{ value: item.name, fontSize: 10 }}
+      onMouseDown={() => selectItem(i)}
+    />
+  ))}
+</UiEntity>
+```
+
+## UiCanvasInformation (Responsive Design)
+
+```typescript
+import { UiCanvasInformation, engine } from '@dcl/sdk/ecs'
+
+const canvasInfo = UiCanvasInformation.get(engine.RootEntity)
+const screenWidth = canvasInfo.width
+const screenHeight = canvasInfo.height
+const pixelRatio = canvasInfo.devicePixelRatio
+```
+
+Use canvas info to adapt UI layout for different screen sizes.
+
+## State Management
+
+React hooks (`useState`, `useEffect`) are NOT available. Use module-level variables:
+
+```typescript
+let score = 0
+let showMenu = false
+
+const UI = () => (
+  <UiEntity uiTransform={{ width: '100%', height: '100%' }}>
+    <Label value={`Score: ${score}`} fontSize={20} />
+    {showMenu && <MenuPanel />}
+  </UiEntity>
+)
+
+// Update from game logic
+export function addScore(points: number) { score += points }
+export function toggleMenu() { showMenu = !showMenu }
+```
+
+The UI re-renders every frame, so module-level variable changes are reflected immediately.
+
+## Important Rules
+
+- File must be `.tsx` for JSX support
+- Only one `ReactEcsRenderer.setUiRenderer()` per scene
+- No React hooks — use module-level variables
+- Use `display: 'none'` to hide elements without removing them
+- UI renders as a 2D overlay on top of the 3D scene

--- a/skills/camera-control/SKILL.md
+++ b/skills/camera-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: camera-control
-description: Control camera behavior in Decentraland scenes. Switch between first-person and third-person with CameraMode, force camera in regions with CameraModeArea, create cinematic scripted cameras with VirtualCamera, and read camera position/rotation via MainCamera. Use when user wants camera control, cinematic views, cutscenes, or camera mode switching.
+description: Control camera behavior in Decentraland scenes. CameraMode detection, CameraModeArea (force first/third person in regions), VirtualCamera (cinematic scripted cameras), MainCamera (read position/rotation), and camera-triggered events. Use when the user wants camera control, cutscenes, cinematic views, forced camera modes, or camera tracking. Do NOT use for input restriction during cutscenes (see advanced-input for InputModifier).
 ---
 
 # Camera Control in Decentraland
@@ -196,6 +196,8 @@ function followNpcCamera(dt: number) {
 
 engine.addSystem(followNpcCamera)
 ```
+
+> **Freezing player during cutscenes?** Combine VirtualCamera with `InputModifier` from the **advanced-input** skill to prevent player movement during cinematic sequences.
 
 ## Best Practices
 

--- a/skills/create-scene/SKILL.md
+++ b/skills/create-scene/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: create-scene
-description: Scaffold a new Decentraland SDK7 scene project from scratch. Creates scene.json, package.json, tsconfig.json, and src/index.ts with a basic scene setup. Use when user wants to start a new scene, initialize a project, or set up from an empty folder.
+description: Scaffold a new Decentraland SDK7 scene project. Creates scene.json, package.json, tsconfig.json, and src/index.ts. Covers scene.json schema (parcels, spawnPoints, permissions, featureToggles), multi-parcel layouts, and project structure. Use when the user wants to start a new scene, create a project, or set up from scratch. Do NOT use for deployment (see deploy-scene or deploy-worlds).
 ---
 
 # Create a New Decentraland SDK7 Scene
+
+> **Runtime constraint:** Decentraland runs in a QuickJS sandbox. No Node.js APIs (`fs`, `http`, `path`, `process`). Use the SDK's `executeTask()` + `fetch()` for async work. See the **scene-runtime** skill for details.
 
 When the user wants to create a new scene, follow these steps:
 
@@ -67,11 +69,73 @@ export function main() {
 }
 ```
 
+### scene.json Reference
+
+All valid `scene.json` fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `ecs7` | Yes | Must be `true` for SDK7 |
+| `runtimeVersion` | Yes | Must be `"7"` |
+| `main` | Yes | Must be `"bin/index.js"` — the compiled output path |
+| `display.title` | Recommended | Scene name shown in the map and Places |
+| `display.description` | Recommended | Short description for discovery |
+| `display.navmapThumbnail` | Optional | Image path for the Genesis City minimap |
+| `scene.parcels` | Yes | Array of `"x,y"` coordinate strings |
+| `scene.base` | Yes | The origin parcel (usually southwest corner) |
+| `spawnPoints` | Optional | Where players appear when entering (see below) |
+| `requiredPermissions` | Optional | Array of permissions (e.g., `"ALLOW_MEDIA_HOSTNAMES"`) |
+| `allowedMediaHostnames` | Optional | Whitelisted domains for external media |
+| `featureToggles` | Optional | Enable/disable SDK features |
+| `worldConfiguration` | Optional | For Worlds deployment (see **deploy-worlds** skill) |
+| `authoritativeMultiplayer` | Optional | Enable authoritative server mode (see **authoritative-server** skill) |
+
+### Spawn Points
+
+Configure where and how players enter the scene:
+
+```json
+{
+  "spawnPoints": [
+    {
+      "name": "spawn1",
+      "default": true,
+      "position": { "x": [1, 5], "y": [0, 0], "z": [2, 4] },
+      "cameraTarget": { "x": 8, "y": 1, "z": 8 }
+    }
+  ]
+}
+```
+
+- Position ranges (e.g., `[1, 5]`) spawn players randomly within the range
+- `cameraTarget` orients the player's camera on spawn — point it at the scene's focal area
+- Fixed spawn: use single values instead of ranges (e.g., `"x": 8`)
+
+### Multi-Parcel Layouts
+
+| Layout | Parcels Array | Use Case |
+|--------|--------------|----------|
+| **Single** | `["0,0"]` | Small games, galleries, single-room experiences |
+| **Strip** | `["0,0", "1,0", "2,0"]` | Hallways, racing tracks, linear journeys |
+| **L-Shape** | `["0,0", "1,0", "0,1"]` | Corner buildings, split experiences |
+| **2x2 Square** | `["0,0", "1,0", "0,1", "1,1"]` | Open plazas, arenas, medium games |
+| **3x3 Square** | 9 parcels from `"0,0"` to `"2,2"` | Large games, multi-room buildings |
+
+**Base parcel:** Always set `scene.base` to the southwest (lowest x,y) corner parcel.
+
+**Boundaries per parcel:** 16m x 16m x 20m height. A 2x2 scene spans 32m x 32m.
+
 ## 5. Post-Creation Steps
 
 After customizing the files:
 1. Use the `preview` tool to start the preview server (or run `npx @dcl/sdk-commands start --bevy-web` manually)
 2. The scene will open in a browser at http://localhost:8000
+
+## Cross-References
+
+- Ready to deploy? See the **deploy-scene** skill (Genesis City) or **deploy-worlds** skill (personal Worlds)
+- Need to optimize for parcel limits? See the **optimize-scene** skill
+- Planning a game? See the **game-design** skill for design patterns and performance budgets
 
 ## Important Notes
 

--- a/skills/deploy-scene/SKILL.md
+++ b/skills/deploy-scene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-scene
-description: Deploy and publish a Decentraland scene to Genesis City (LAND-based). Use when user wants to deploy, publish, upload, go live, or make their scene accessible on parcels they own.
+description: Deploy a Decentraland scene to Genesis City (LAND-based). Covers pre-deployment checklist, scene.json validation, spawn points, and common deployment errors. Use when the user wants to deploy, publish, go live, or upload to parcels they own. Do NOT use for Worlds deployment (see deploy-worlds).
 ---
 
 # Deploying to Genesis City
@@ -38,13 +38,7 @@ Before deploying, verify:
    npm install
    ```
 
-5. **Assets are within limits** (check parcel count):
-   | Parcels | Entities | Triangles | Textures |
-   |---------|----------|-----------|----------|
-   | 1 | 512 | 10,000 | 10 MB |
-   | 2 | 1,024 | 20,000 | 20 MB |
-   | 4 | 2,048 | 40,000 | 40 MB |
-   | 8+ | Scales linearly | | |
+5. **Assets are within limits** — see the **optimize-scene** skill for full limit formulas per parcel count (triangles, entities, materials, textures, height)
 
 ## Deployment Process
 
@@ -79,7 +73,7 @@ npx @dcl/sdk-commands deploy
     "parcels": ["0,0", "0,1"],
     "base": "0,0"
   },
-  "main": "bin/index.js",
+  "main": "bin/index.js"
 }
 ```
 
@@ -101,6 +95,29 @@ Configure where players appear when entering the scene:
 ```
 
 Position ranges (e.g., `[1, 5]`) spawn players randomly within the range. Use `cameraTarget` to orient the player's camera on spawn.
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "You don't have permission to deploy" | Wallet doesn't own the target LAND/parcels | Verify LAND ownership on the marketplace, or get deployment permissions from the LAND owner |
+| "Scene is too large" | Assets exceed parcel size limits | Check triangle count, file sizes, and texture counts against the limits table above. See **optimize-scene** skill |
+| Wallet connection fails | Browser popup blocked or MetaMask locked | Allow popups, unlock MetaMask, refresh and try again |
+| "Invalid scene.json" | Missing required fields or malformed JSON | Verify `ecs7: true`, `runtimeVersion: "7"`, valid `parcels` array, and `main: "bin/index.js"` |
+| Deploy succeeds but scene is empty | `main` field doesn't point to compiled output | Ensure `main` is `"bin/index.js"` and run `npx @dcl/sdk-commands build` first |
+| Catalyst rejection | Content violates Decentraland content policies | Review content guidelines at docs.decentraland.org |
+
+### Genesis City vs Worlds
+
+| | Genesis City | Worlds |
+|-|-------------|--------|
+| **Requirement** | Own LAND parcels | Own DCL NAME or ENS domain |
+| **Parcel limits** | Enforced (entity/triangle budgets per parcel) | Not constrained by LAND |
+| **Visibility** | Shown on the Genesis City map | Listed on Places page (opt-out available) |
+| **Deploy target** | Default Catalyst network | `--target-content https://worlds-content-server.decentraland.org` |
+| **Best for** | Permanent installations, high-traffic scenes | Testing, personal spaces, events |
+
+> **Deploying to a World instead?** See the **deploy-worlds** skill.
 
 ## Best Practices
 

--- a/skills/deploy-worlds/SKILL.md
+++ b/skills/deploy-worlds/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-worlds
-description: Deploy and publish a Decentraland scene to a World (personal 3D space). Use when user wants to deploy to a World, publish to a World, set up worldConfiguration, use a DCL NAME or ENS domain for deployment, or opt out of Places listing.
+description: Deploy a Decentraland scene to a World (personal 3D space using a DCL NAME or ENS domain). Covers worldConfiguration setup, Places listing opt-out, and common deployment errors. Use when the user wants to deploy to a World, publish to a personal space, or use a DCL NAME/ENS domain. Do NOT use for Genesis City LAND deployment (see deploy-scene).
 ---
 
 # Deploying to Decentraland Worlds
@@ -98,6 +98,18 @@ From inside Decentraland, use the chatbox command:
   }
 }
 ```
+
+## Troubleshooting
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "NAME not found" or "NAME not owned" | The wallet signing the deployment doesn't own the NAME/ENS in `worldConfiguration.name` | Verify NAME ownership at `https://builder.decentraland.org/names`. The wallet used for signing must own the exact NAME |
+| ENS resolution fails | ENS domain not registered or expired | Check ENS registration at `https://app.ens.domains` |
+| "Scene too large" | World scenes have size limits even though parcels aren't constrained | Reduce asset sizes. Worlds still enforce file size and entity limits |
+| Deploy succeeds but world is empty | `main` field misconfigured | Ensure `main` is `"bin/index.js"` and code compiles |
+| World not showing on Places | Propagation delay | Wait a few minutes after deployment. If opted out via `placesConfig.optOut`, it won't appear |
+
+> **Deploying to Genesis City instead?** See the **deploy-scene** skill.
 
 ## Key Differences from Genesis City
 

--- a/skills/game-design/SKILL.md
+++ b/skills/game-design/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: game-design
+description: Plan and design Decentraland games and interactive experiences. Scene limit formulas, performance budgets, texture requirements, asset preloading, state management patterns (module-level, component-based, state machines), object pooling, UX/UI guidelines, input design, and MVP planning. Use when the user wants game design advice, scene architecture, performance planning, or help structuring a game. Do NOT use for specific implementation (see add-interactivity, build-ui, multiplayer-sync).
+---
+
+# Decentraland Game Design & Scene Optimization
+
+## 1. DCL Game Design Philosophy
+
+Decentraland is a **continuous, shared 3D world**. Design around these constraints:
+
+- **No startup screen**: The scene is always live. Players walk in from adjacent parcels — there is no splash screen, no "press start." Your scene must be meaningful the instant a player arrives.
+- **No forced endings**: You cannot force a "game over" state. Players can leave at any time by walking away or teleporting. Design loops that accommodate drop-in / drop-out naturally.
+- **Cannot remove players**: There is no API to eject a player from a scene. You can teleport a player, but only with their consent (they must accept the prompt). Design around misbehaving players with game mechanics, not eviction.
+- **Boundary awareness**: Players standing outside your parcel can see into it. Your scene is always on display. Neighboring scenes are visible too — consider visual harmony.
+- **Shared space**: Multiple players are always potentially present. Even a "single-player" puzzle is witnessed by others. Embrace or account for this.
+
+## 2. Scene Limitation Formulas
+
+All limits scale with parcel count `n`. Know these formulas and design within them.
+
+| Resource | Formula | 1 parcel | 2 parcels | 4 parcels | 9 parcels | 16 parcels |
+|---|---|---|---|---|---|---|
+| **Triangles** | n x 10,000 | 10,000 | 20,000 | 40,000 | 90,000 | 160,000 |
+| **Entities** | n x 200 | 200 | 400 | 800 | 1,800 | 3,200 |
+| **Physics bodies** | n x 300 | 300 | 600 | 1,200 | 2,700 | 4,800 |
+| **Materials** | log2(n+1) x 20 | 20 | 31 | 46 | 66 | 81 |
+| **Textures** | log2(n+1) x 10 | 10 | 15 | 23 | 33 | 40 |
+| **Height limit** | log2(n+1) x 20m | 20m | 31m | 46m | 66m | 81m |
+| **Draw calls** | n x 300 (target) | 300 | 600 | 1,200 | 2,700 | 4,800 |
+
+**File limits:** 15 MB per parcel, 300 MB max total, 200 files per parcel, 50 MB max per individual file.
+
+## 3. Texture Requirements
+
+- **Dimensions must be power-of-two**: 256, 512, 1024, 2048
+- **Recommended sizes**: 1024x1024 for scene objects, 512x512 for wearables
+- **Avoid textures over 2048x2048** — they consume excessive memory and often exceed limits
+- **Use texture atlases** to combine multiple small textures into one, reducing draw calls and material count
+- Prefer compressed formats (WebP) over raw PNG where possible
+- Share texture references across materials — do not duplicate texture files
+
+## 4. Asset Preloading (AssetLoad Component)
+
+For large assets that would cause visible pop-in, use `AssetLoad` to pre-download before rendering:
+
+```typescript
+import { engine, AssetLoad, LoadingState, GltfContainer, Transform } from '@dcl/sdk/ecs'
+import { Vector3 } from '@dcl/sdk/math'
+
+const preloadEntity = engine.addEntity()
+AssetLoad.create(preloadEntity, { src: 'models/large-model.glb' })
+
+function assetLoadingSystem(dt: number) {
+  for (const [entity] of engine.getEntitiesWith(AssetLoad)) {
+    const state = AssetLoad.get(entity)
+    if (state.loadingState === LoadingState.FINISHED) {
+      GltfContainer.create(entity, { src: 'models/large-model.glb' })
+      Transform.create(entity, { position: Vector3.create(8, 0, 8) })
+      AssetLoad.deleteFrom(entity)
+    }
+  }
+}
+engine.addSystem(assetLoadingSystem)
+```
+
+Use this pattern for any model over ~1 MB or for assets that should be ready before a game phase begins.
+
+## 5. Performance Patterns
+
+### Object Pooling
+Reuse entities instead of creating and destroying them:
+
+```typescript
+const pool: Entity[] = []
+
+function getFromPool(): Entity {
+  const existing = pool.pop()
+  if (existing) return existing
+  return engine.addEntity()
+}
+
+function returnToPool(entity: Entity) {
+  Transform.getMutable(entity).position = Vector3.create(0, -100, 0)
+  pool.push(entity)
+}
+```
+
+### LOD (Level of Detail)
+Swap models or hide entities based on distance from the player:
+
+```typescript
+function lodSystem() {
+  const playerPos = Transform.get(engine.PlayerEntity).position
+  for (const [entity, transform] of engine.getEntitiesWith(Transform, GltfContainer)) {
+    const distance = Vector3.distance(playerPos, transform.position)
+    VisibilityComponent.createOrReplace(entity, { visible: distance <= 30 })
+  }
+}
+engine.addSystem(lodSystem)
+```
+
+### Draw Call Reduction
+- Merge meshes in Blender before export
+- Use texture atlases (one material for many objects)
+- Limit unique materials — reuse them across entities
+- Avoid transparency when possible (transparent objects cost extra draw calls)
+
+### System Optimization
+- Do NOT run heavy logic every frame. Use timers:
+  ```typescript
+  let timer = 0
+  function heavySystem(dt: number) {
+    timer += dt
+    if (timer < 0.5) return // Run every 500ms, not every frame
+    timer = 0
+    // ... expensive work here
+  }
+  ```
+- Minimize `engine.getEntitiesWith()` queries — cache results when entity sets are stable
+- Avoid allocating new objects (Vector3.create, arrays) inside systems that run every frame
+
+### Disable Unused Colliders
+Remove collision meshes from decorative objects that players never interact with. This reduces physics body count significantly.
+
+## 6. Input System Design
+
+| Input | Action | Notes |
+|---|---|---|
+| **E key** | Primary action (`IA_PRIMARY`) | Main interaction |
+| **F key** | Secondary action (`IA_SECONDARY`) | Alternate interaction |
+| **Pointer click** | `IA_POINTER` | Left mouse click / tap |
+| **Keys 1-4** | `IA_ACTION_3` through `IA_ACTION_6` | Action bar slots |
+
+### Design Considerations
+- Mouse wheel is **not available** as an input
+- Always design for both **desktop and mobile**. Mobile has no keyboard — rely on pointer and on-screen buttons
+- Set `maxDistance` on pointer events (8-10 meters typical) to prevent interactions from across the scene
+- Use `hoverText` to communicate what an interaction does before the player commits
+
+## 7. State Management Patterns
+
+### Module-Level State (Simple Games)
+```typescript
+// game-state.ts
+export let score = 0
+export let gamePhase: 'waiting' | 'playing' | 'ended' = 'waiting'
+export function addScore(points: number) { score += points }
+```
+
+### Component-Based State (Complex Games)
+Use custom components as structured data containers:
+```typescript
+import { engine, Schemas } from '@dcl/sdk/ecs'
+
+const EnemyState = engine.defineComponent('EnemyState', {
+  health: Schemas.Number,
+  speed: Schemas.Number,
+  target: Schemas.Entity
+})
+```
+
+### State Machines
+Model game phases as explicit states with clear transitions:
+```typescript
+type GameState = 'lobby' | 'countdown' | 'active' | 'cooldown'
+let currentState: GameState = 'lobby'
+
+function gameStateSystem(dt: number) {
+  switch (currentState) {
+    case 'lobby': handleLobby(dt); break
+    case 'countdown': handleCountdown(dt); break
+    case 'active': handleActive(dt); break
+    case 'cooldown': handleCooldown(dt); break
+  }
+}
+```
+
+## 8. UX/UI Guidelines
+
+- **Keep UI minimal**: The metaverse is about 3D presence, not 2D overlays. Avoid large HUDs that obscure the world.
+- **Prefer spatial UI**: Use `TextShape` on entities and 3D signs over screen-space UI whenever the information is tied to a place or object.
+- **Clear affordances**: Interactive objects should look interactive. Use glow effects, outlines, floating indicators, or subtle animations to signal "you can click this."
+- **Sound feedback**: Every significant player action should produce audio feedback. It confirms the action registered and adds polish.
+- **Progressive disclosure**: Do not dump all information at once. Reveal mechanics and story as the player engages. Start simple, layer complexity.
+- **Immediate feedback**: When a player interacts, respond within the same frame. Use tweens, sounds, or UI popups so the player never wonders "did that work?"
+- **Accessibility**: Use high-contrast text, readable font sizes (fontSize >= 16 for screen UI), and audio cues alongside visual ones.
+
+## 9. MVP Planning
+
+### Start with the Core Loop
+Ask: **What does the player DO?** The answer should be a single sentence:
+- "The player explores rooms and finds hidden objects."
+- "The player races other players through an obstacle course."
+- "The player collects resources and builds structures."
+
+### Prototype Fast
+- Build in **1-2 parcels** first, even if the final scene will be larger
+- Use primitive shapes (boxes, spheres) as placeholders — do not wait for final art
+- Get the core loop working before adding any secondary features
+
+### Test Early
+- Deploy to a test world and walk through it yourself
+- Invite 2-3 real players and watch them (do not explain the game — see if it is self-explanatory)
+- Measure: Do players understand what to do within 30 seconds?
+
+### Iterate on Fun
+- Polish comes last. If the core loop is not fun with placeholder art, better art will not fix it
+- Cut features aggressively. A tight, small experience beats a sprawling, unfinished one
+- Replay value matters more than content volume in DCL (players return to scenes they enjoy)
+
+### MVP Checklist
+- Core loop is playable in under 60 seconds
+- Works with 1 player and with 5+ players simultaneously
+- Fits within scene limits for target parcel count
+- Has clear visual/audio feedback for all interactions
+- Player understands the goal without external instructions
+
+> **Starting from scratch?** See the **create-scene** skill first to scaffold the project before designing the game.
+
+## 10. Cross-References
+
+| Topic | Skill | When to Use |
+|---|---|---|
+| Interactivity, input handling, raycasting | **add-interactivity** | Implementing click handlers, triggers, input |
+| Multiplayer sync, server communication | **multiplayer-sync** | Networked game state, real-time sync |
+| Screen UI, React-ECS, HUD elements | **build-ui** | Building menus, scoreboards, dialogs |
+| Performance optimization, entity/triangle budgets | **optimize-scene** | Detailed optimization techniques |
+
+This skill focuses on the **design decisions and optimization constraints** that shape implementations. For detailed code patterns, see the referenced skills.

--- a/skills/lighting-environment/SKILL.md
+++ b/skills/lighting-environment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lighting-environment
-description: Add dynamic lighting and control environment settings in Decentraland scenes. Create point, spot, and directional lights with LightSource, configure shadows, control day/night cycle with SkyboxTime, detect realm info, and use emissive materials for glow effects. Use when user wants lights, shadows, skybox, day-night cycle, or glowing materials.
+description: Dynamic lighting and environment in Decentraland scenes. LightSource (point and spot lights), shadows, SkyboxTime (day/night cycle), realm detection, and emissive materials for glow effects. Use when the user wants lights, shadows, skybox control, day-night cycle, or glowing materials. Do NOT use for PBR material properties like metallic/roughness (see advanced-rendering).
 ---
 
 # Lighting and Environment in Decentraland
@@ -126,15 +126,15 @@ executeTask(async () => {
 ### Change Time Dynamically
 
 ```typescript
-import { SkyboxTime, TransitionMode } from '~system/Runtime'
+import { engine, SkyboxTime } from '@dcl/sdk/ecs'
 
 // Set time of day (must target root entity)
-SkyboxTime.create(engine.RootEntity, { fixed_time: 36000 })  // Noon
+SkyboxTime.create(engine.RootEntity, { fixedTime: 36000 })  // Noon
 
-// Change with transition direction
+// Change with transition direction (TransitionMode from the generated protobuf)
 SkyboxTime.createOrReplace(engine.RootEntity, {
-  fixed_time: 54000,  // Dusk
-  direction: TransitionMode.TM_BACKWARD
+  fixedTime: 54000,  // Dusk
+  transitionMode: 1  // TM_BACKWARD
 })
 ```
 
@@ -147,7 +147,7 @@ const CYCLE_SPEED = 100  // Time units per second
 function dayNightCycle(dt: number) {
   currentTime = (currentTime + CYCLE_SPEED * dt) % 72000
   SkyboxTime.createOrReplace(engine.RootEntity, {
-    fixed_time: currentTime
+    fixedTime: currentTime
   })
 }
 
@@ -207,21 +207,29 @@ LightSource.create(bulb, {
 
 ### Shadow Types
 
-LightSource supports three shadow modes:
-
-- `PBLightSource_ShadowType.ST_NONE` — no shadows (cheapest)
-- `PBLightSource_ShadowType.ST_HARD` — crisp shadows (medium cost)
-- `PBLightSource_ShadowType.ST_SOFT` — smooth, blurred shadows (most expensive)
+Control shadow quality per light. Shadow type is set inside the `Spot()` or `Point()` helper:
 
 ```typescript
 import { LightSource, PBLightSource_ShadowType } from '@dcl/sdk/ecs'
 
+// Spot light with soft shadows
 LightSource.create(spotEntity, {
-  type: LightSourceType.LST_SPOT,
-  intensity: 50,
-  shadow: PBLightSource_ShadowType.ST_SOFT
+  type: LightSource.Type.Spot({
+    innerAngle: 25,
+    outerAngle: 45,
+    shadow: PBLightSource_ShadowType.ST_SOFT
+  }),
+  shadow: true,
+  intensity: 800
 })
 ```
+
+Available shadow types:
+- `PBLightSource_ShadowType.ST_NONE` — no shadows (cheapest)
+- `PBLightSource_ShadowType.ST_HARD` — crisp shadows (medium cost)
+- `PBLightSource_ShadowType.ST_SOFT` — smooth, blurred shadows (most expensive)
+
+> **Need advanced material effects?** See the **advanced-rendering** skill for metallic, roughness, transparency, texture maps, and texture modes.
 
 ## Best Practices
 

--- a/skills/multiplayer-sync/SKILL.md
+++ b/skills/multiplayer-sync/SKILL.md
@@ -1,41 +1,81 @@
 ---
 name: multiplayer-sync
-description: Synchronize state between players in Decentraland multiplayer scenes using CRDT-based networking. Use when user wants multiplayer, sync state, network entities, shared world state, or real-time collaboration.
+description: Synchronize state between players in Decentraland using CRDT networking (syncEntity), MessageBus, fetch, signedFetch, and WebSocket. Use when the user wants multiplayer, synced entities, shared world state, real-time networking, or player-to-player communication. Do NOT use for server-authoritative multiplayer with anti-cheat (see authoritative-server). Do NOT use for screen UI (see build-ui).
 ---
 
 # Multiplayer Synchronization in Decentraland
 
 Decentraland scenes are inherently multiplayer. All players in the same scene share the same space. SDK7 uses CRDT-based synchronization.
 
-## How Sync Works
+> **Runtime constraint:** Decentraland runs in a QuickJS sandbox. No Node.js APIs (`fs`, `http`, `path`, `process`). Use `fetch()` and `WebSocket` for network communication. See the **scene-runtime** skill for async patterns.
 
-- Entities must be explicitly synced using `syncEntity()` from `@dcl/sdk/network`.
-- The Decentraland runtime uses CRDTs (Conflict-free Replicated Data Types) to resolve conflicts.
-- Last-write-wins semantics for most components (Transform, Material, etc.).
-- No server code needed — sync is built into the runtime.
+## Sync Strategy Decision Tree
 
-## Basic Synced Entity
+Choose the right networking approach based on what you need:
 
-Use `syncEntity()` to mark an entity and its components for multiplayer sync:
+| Strategy | Use When | Persistence | Example |
+|----------|----------|-------------|---------|
+| `syncEntity` | Shared state that all players see and that persists for new arrivals | Yes — state survives player join/leave | Doors, switches, scoreboards, elevators |
+| `MessageBus` | Ephemeral events that only matter in the moment | No — late joiners miss past messages | Chat messages, sound effects, particle triggers |
+| `fetch` / REST API | Reading or writing data to an external server | Server-dependent | Leaderboards, inventory, external game state |
+| `signedFetch` | Authenticated requests that prove player identity | Server-dependent | Claiming rewards, submitting verified scores |
+| `WebSocket` | Real-time bidirectional communication with a server | Connection-dependent | Live game servers, real-time chat, authoritative multiplayer |
+
+**Decision flow:**
+1. Does every player need to see the same state, including late joiners? --> `syncEntity`
+2. Is it a fire-and-forget event only for players currently in the scene? --> `MessageBus`
+3. Do you need to talk to an external server? --> `fetch` or `signedFetch`
+4. Do you need continuous real-time server communication? --> `WebSocket`
+5. Combine approaches freely: use `syncEntity` for world state, `MessageBus` for effects, and `fetch` for persistence.
+
+---
+
+## syncEntity Essentials
+
+### Import and Basic Usage
 
 ```typescript
 import { engine, Transform, MeshRenderer, Material } from '@dcl/sdk/ecs'
 import { syncEntity } from '@dcl/sdk/network'
 import { Vector3, Color4 } from '@dcl/sdk/math'
+```
 
-// Create entity
-const sharedCube = engine.addEntity()
-Transform.create(sharedCube, { position: Vector3.create(8, 1, 8) })
-MeshRenderer.setBox(sharedCube)
-Material.setPbrMaterial(sharedCube, { albedoColor: Color4.Red() })
+Signature: `syncEntity(entity, componentIds[], syncId?)`
 
-// Sync this entity's Transform to all players
-syncEntity(sharedCube, [Transform.componentId])
+- `entity` — the entity to synchronize
+- `componentIds[]` — array of component IDs to keep in sync (e.g., `[Transform.componentId]`)
+- `syncId` — unique numeric identifier (required for predefined entities, optional for player-spawned entities)
 
-// When any player changes the transform, all players see it
-function moveCube() {
-  const transform = Transform.getMutable(sharedCube)
-  transform.position.x += 1  // All players see this change
+### Enum Sync IDs (Predefined Entities)
+
+Every predefined synced entity MUST have a unique numeric ID. Use an enum to avoid collisions:
+
+```typescript
+enum SyncIds {
+  DOOR = 1,
+  ELEVATOR = 2,
+  SCOREBOARD = 3
+}
+
+const door = engine.addEntity()
+Transform.create(door, { position: Vector3.create(8, 1, 8) })
+MeshRenderer.setBox(door)
+syncEntity(door, [Transform.componentId, MeshRenderer.componentId], SyncIds.DOOR)
+```
+
+Predefined entities (with a sync ID) persist after the creating player leaves. Player-created entities (no sync ID) are removed when the player disconnects.
+
+### Auto-Generated IDs (Player-Spawned Entities)
+
+Entities created at runtime by players do not need an explicit sync ID:
+
+```typescript
+function createProjectile() {
+  const projectile = engine.addEntity()
+  Transform.create(projectile, { position: Vector3.create(4, 1, 4) })
+  MeshRenderer.setSphere(projectile)
+  syncEntity(projectile, [Transform.componentId])
+  return projectile
 }
 ```
 
@@ -47,19 +87,16 @@ Define custom components and sync them between players:
 import { engine, Schemas } from '@dcl/sdk/ecs'
 import { syncEntity } from '@dcl/sdk/network'
 
-// Define a custom component
 const ScoreBoard = engine.defineComponent('scoreBoard', {
   score: Schemas.Int,
   playerName: Schemas.String,
   lastUpdated: Schemas.Int64
 })
 
-// Create and sync the entity
 const board = engine.addEntity()
 ScoreBoard.create(board, { score: 0, playerName: '', lastUpdated: 0 })
 syncEntity(board, [ScoreBoard.componentId])
 
-// Update from any player — synced via CRDT
 function addScore(points: number) {
   const data = ScoreBoard.getMutable(board)
   data.score += points
@@ -103,69 +140,47 @@ Available schema types for custom components:
 | `Schemas.Optional(innerType)` | Nullable values |
 | `Schemas.Enum(enumType)` | Enum values |
 
-## Communication Patterns
+## Parent-Child Sync Relationships
 
-### Global State (Shared Object)
-```typescript
-// One entity holds shared game state
-const gameState = engine.addEntity()
-const GameState = engine.defineComponent('gameState', {
-  phase: Schemas.String,
-  timeRemaining: Schemas.Int,
-  isActive: Schemas.Boolean
-})
-GameState.create(gameState, { phase: 'waiting', timeRemaining: 60, isActive: false })
-```
-
-### Per-Player State
-```typescript
-// Track each player's state separately using their entity
-engine.addSystem(() => {
-  for (const [entity] of engine.getEntitiesWith(PlayerIdentityData)) {
-    // Each player's entity is unique to them
-    // Attach custom components to player entities for per-player data
-  }
-})
-```
-
-### Entity Enum IDs
-
-Distinguish predefined entities from player-created ones using `entityEnumId`:
+For synced entities with parent-child relationships, use `parentEntity()` instead of setting `Transform.parent`:
 
 ```typescript
-syncEntity(door, [Transform.componentId], 1)   // predefined entity (enum ID 1)
-syncEntity(door2, [Transform.componentId], 2)  // predefined entity (enum ID 2)
-syncEntity(playerBox, [Transform.componentId]) // no enum ID = player-created, lives with the player
-```
+import { syncEntity, parentEntity, getParent, getChildren, removeParent } from '@dcl/sdk/network'
 
-Predefined entities (with an `entityEnumId`) persist after the creating player leaves. Player-created entities (no enum ID) are removed when the player disconnects.
+const parent = engine.addEntity()
+const child = engine.addEntity()
 
-### Parent-Child Relationships
+syncEntity(parent, [Transform.componentId], 1)
+syncEntity(child, [Transform.componentId], 2)
 
-Use `parentEntity` to create entity hierarchies that sync correctly:
-
-```typescript
-import { parentEntity, getParent, getChildren } from '@dcl/sdk/ecs'
-
+// Use parentEntity() — NOT Transform.parent
 parentEntity(child, parent)
-const parent = getParent(child)
-const children = getChildren(parent)
+
+const parentRef = getParent(child)
+const childrenArray = Array.from(getChildren(parent))
+
+// Remove parent relationship
+removeParent(child)
 ```
 
-### Connection State
+## Connection State
 
 Check if the player is connected to the sync room:
 
 ```typescript
-import { isStateSynchronized } from '@dcl/sdk/ecs'
+import { isStateSyncronized } from '@dcl/sdk/network'
 
 engine.addSystem(() => {
-  if (!isStateSynchronized()) return // wait for sync
+  if (!isStateSyncronized()) return // wait for sync
   // safe to read/write synced state
 })
 ```
 
-### MessageBus
+**Note:** The function is spelled `isStateSyncronized` (not "Synchronized") in the SDK.
+
+---
+
+## MessageBus
 
 Send custom messages between players (fire-and-forget, no persistence):
 
@@ -173,30 +188,128 @@ Send custom messages between players (fire-and-forget, no persistence):
 import { MessageBus } from '@dcl/sdk/message-bus'
 
 const bus = new MessageBus()
+
 bus.on('hit', (data: { damage: number }) => {
   console.log('Took damage:', data.damage)
 })
+
 bus.emit('hit', { damage: 10 })
 ```
 
-### Player Enter/Leave Events
+### syncEntity vs MessageBus
+
+- `syncEntity`: state is persistent, late joiners get current state, automatic conflict resolution
+- `MessageBus`: fire-and-forget, late joiners miss past messages, good for transient effects
+- Combine both: use `syncEntity` for the door open/closed state, `MessageBus` for the sound effect when it opens
+
+---
+
+## REST API Calls (fetch)
+
+All network calls must run inside `executeTask` because the SDK runtime does not support top-level await.
+
+```typescript
+import { executeTask } from '@dcl/sdk/ecs'
+
+executeTask(async () => {
+  try {
+    const response = await fetch('https://api.example.com/data')
+    if (!response.ok) {
+      console.error('HTTP error:', response.status)
+      return
+    }
+    const data = await response.json()
+    console.log('Response:', data)
+  } catch (error) {
+    console.error('Network error:', error)
+  }
+})
+```
+
+## Signed Fetch (Authenticated Requests)
+
+`signedFetch` attaches a cryptographic signature proving the player's identity:
+
+```typescript
+import { signedFetch } from '~system/SignedFetch'
+
+executeTask(async () => {
+  try {
+    const response = await signedFetch({
+      url: 'https://example.com/api/action',
+      init: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'claimReward', amount: 100 })
+      }
+    })
+    if (!response.ok) {
+      console.error('HTTP error:', response.status)
+      return
+    }
+    const result = JSON.parse(response.body)
+    console.log('Result:', result)
+  } catch (error) {
+    console.log('Request failed:', error)
+  }
+})
+```
+
+---
+
+## WebSocket Connections
+
+For full WebSocket patterns (reconnection, heartbeat, message format), see `{baseDir}/references/networking-patterns.md`.
+
+### Basic Connection
+
+```typescript
+executeTask(async () => {
+  const ws = new WebSocket('wss://example.com/ws')
+
+  ws.onopen = () => {
+    console.log('Connected to WebSocket')
+    ws.send(JSON.stringify({ type: 'join', playerId: 'player123' }))
+  }
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data)
+    switch (msg.type) {
+      case 'gameState': handleGameState(msg); break
+      case 'playerJoin': handlePlayerJoin(msg); break
+      case 'playerLeave': handlePlayerLeave(msg); break
+    }
+  }
+
+  ws.onerror = (error) => console.error('WebSocket error:', error)
+  ws.onclose = () => console.log('Disconnected')
+})
+```
+
+---
+
+## Player Enter/Leave Events
 
 Detect players entering or leaving the scene:
 
 ```typescript
-import { onEnterScene, onLeaveScene } from '@dcl/sdk/observables'
+import { onEnterScene, onLeaveScene } from '@dcl/sdk/src/players'
 
-onEnterScene.add((player) => {
+onEnterScene((player) => {
   console.log('Player entered:', player.userId)
 })
-onLeaveScene.add((player) => {
-  console.log('Player left:', player.userId)
+onLeaveScene((userId) => {
+  console.log('Player left:', userId)
 })
 ```
 
-### Offline Testing
+## Multiplayer Testing
 
-Test multiplayer locally without a server using the offline adapter:
+Open multiple browser windows to test multiplayer locally. Each window is a separate player.
+
+### Offline Mode
+
+For Decentraland Worlds that do not need multiplayer:
 
 ```json
 {
@@ -205,6 +318,19 @@ Test multiplayer locally without a server using the offline adapter:
   }
 }
 ```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| State not syncing between players | Missing `syncEntity()` call | Every entity you want shared must call `syncEntity(entity, [ComponentId1, ComponentId2])` |
+| Sync ID collision | Two entities share the same numeric sync ID | Use an enum to assign unique IDs to every predefined synced entity |
+| Entity disappears when creator leaves | No sync ID provided | Add a sync ID (third argument) to `syncEntity()` for entities that should persist |
+| `Date.now()` values corrupted | Using `Schemas.Number` for timestamps | Use `Schemas.Int64` for any number over 13 digits (like `Date.now()`) |
+| State not ready on join | Reading synced state before sync completes | Guard with `if (!isStateSyncronized()) return` in your system |
+| MessageBus messages lost | Late joiner expecting past messages | MessageBus is fire-and-forget. Use `syncEntity` for persistent state |
+
+> **Need server-side validation or anti-cheat?** See the **authoritative-server** skill for the headless server pattern.
 
 ## Important Notes
 

--- a/skills/multiplayer-sync/references/networking-patterns.md
+++ b/skills/multiplayer-sync/references/networking-patterns.md
@@ -1,0 +1,238 @@
+# Networking Patterns Reference
+
+## WebSocket Connection Patterns
+
+### Basic Connection
+
+```typescript
+import { executeTask } from '@dcl/sdk/ecs'
+
+executeTask(async () => {
+  const ws = new WebSocket('wss://example.com/ws')
+
+  ws.onopen = () => {
+    console.log('Connected to WebSocket')
+    ws.send('Hello Server!')
+  }
+
+  ws.onmessage = (event) => {
+    console.log('Received:', event.data)
+  }
+
+  ws.onerror = (error) => {
+    console.error('WebSocket error:', error)
+  }
+
+  ws.onclose = () => {
+    console.log('Disconnected from WebSocket')
+  }
+})
+```
+
+### Reconnection with Exponential Backoff
+
+```typescript
+executeTask(async () => {
+  let ws: WebSocket | null = null
+  let reconnectAttempts = 0
+  const maxReconnectAttempts = 5
+
+  function connect() {
+    ws = new WebSocket('wss://example.com/ws')
+
+    ws.onopen = () => {
+      console.log('Connected')
+      reconnectAttempts = 0
+    }
+
+    ws.onclose = () => {
+      if (reconnectAttempts < maxReconnectAttempts) {
+        reconnectAttempts++
+        setTimeout(connect, 1000 * reconnectAttempts) // exponential backoff
+      }
+    }
+
+    ws.onerror = (error) => {
+      console.error('WebSocket error:', error)
+    }
+  }
+
+  connect()
+})
+```
+
+### Heartbeat Pattern
+
+Send periodic pings to keep the connection alive:
+
+```typescript
+ws.onopen = () => {
+  const heartbeat = setInterval(() => {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: 'ping' }))
+    } else {
+      clearInterval(heartbeat)
+    }
+  }, 30000) // every 30 seconds
+}
+```
+
+### JSON Message Format Convention
+
+Use a `type` field for structured communication:
+
+```typescript
+// Send
+ws.send(JSON.stringify({ type: 'playerMove', position: { x: 8, y: 1, z: 8 } }))
+
+// Receive and dispatch
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data)
+  switch (msg.type) {
+    case 'gameState': handleGameState(msg); break
+    case 'playerJoin': handlePlayerJoin(msg); break
+    case 'playerLeave': handlePlayerLeave(msg); break
+  }
+}
+```
+
+## fetch / signedFetch Error Handling
+
+### Robust fetch Pattern
+
+```typescript
+import { executeTask } from '@dcl/sdk/ecs'
+
+executeTask(async () => {
+  try {
+    const response = await fetch('https://api.example.com/data')
+    if (!response.ok) {
+      console.error('HTTP error:', response.status)
+      return
+    }
+    const data = await response.json()
+    // use data
+  } catch (error) {
+    console.error('Network error:', error)
+  }
+})
+```
+
+### POST Request
+
+```typescript
+executeTask(async () => {
+  try {
+    const response = await fetch('https://api.example.com/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'player123', score: 1500 })
+    })
+    const result = await response.json()
+    console.log('Submission result:', result)
+  } catch (error) {
+    console.log('Submission failed:', error)
+  }
+})
+```
+
+### signedFetch for Authenticated Requests
+
+`signedFetch` attaches a cryptographic signature proving the player's identity. Your backend can verify this signature to authenticate requests.
+
+```typescript
+import { signedFetch } from '~system/SignedFetch'
+
+executeTask(async () => {
+  try {
+    const response = await signedFetch({
+      url: 'https://example.com/api/claim',
+      init: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'claimReward', amount: 100 })
+      }
+    })
+    if (!response.ok) {
+      console.error('HTTP error:', response.status)
+      return
+    }
+    const result = JSON.parse(response.body)
+    console.log('Claim result:', result)
+  } catch (error) {
+    console.log('Claim failed:', error)
+  }
+})
+```
+
+## MessageBus Typed Payloads
+
+Define types for message data to keep code safe:
+
+```typescript
+import { MessageBus } from '@dcl/sdk/message-bus'
+
+type SpawnMessage = {
+  position: { x: number; y: number; z: number }
+  entityEnumId: number
+}
+
+type ChatMessage = {
+  sender: string
+  text: string
+  timestamp: number
+}
+
+const bus = new MessageBus()
+
+bus.on('spawn', (message: SpawnMessage) => {
+  const entity = engine.addEntity()
+  Transform.create(entity, {
+    position: Vector3.create(message.position.x, message.position.y, message.position.z)
+  })
+})
+
+bus.on('chat', (msg: ChatMessage) => {
+  console.log(`[${msg.sender}]: ${msg.text}`)
+})
+```
+
+## Architecture Patterns
+
+### Optimistic Updates
+
+Apply changes locally immediately, then let sync propagate. With `syncEntity`, local mutations are shown instantly while the SDK handles replication:
+
+```typescript
+// Player clicks a door — update locally, sync handles the rest
+Transform.getMutable(door).rotation = Quaternion.fromEulerDegrees(0, 90, 0)
+```
+
+### Authority Models
+
+- **Decentralized (syncEntity):** Any player can mutate synced components. Good for simple shared objects.
+- **Authoritative server (WebSocket):** Server validates and broadcasts state. Use for competitive games, economies, or anti-cheat.
+- **Hybrid:** Use `syncEntity` for world objects, WebSocket for game logic validation.
+
+### Multiplayer Testing
+
+Open multiple browser windows to test multiplayer locally:
+
+1. Use the Creator Hub Preview button multiple times (each window is a separate player)
+2. Or use the URL: `decentraland://realm=http://127.0.0.1:8000&local-scene=true&debug=true`
+
+```typescript
+// Track active players
+function multiplayerTestSystem() {
+  const players = Array.from(engine.getEntitiesWith(PlayerIdentityData))
+  console.log(`Active players: ${players.length}`)
+
+  players.forEach(([entity, playerData]) => {
+    const transform = Transform.getOrNull(entity)
+    if (transform) {
+      console.log(`Player ${playerData.address} at:`, transform.position)
+    }
+  })
+}
+engine.addSystem(multiplayerTestSystem)
+```

--- a/skills/nft-blockchain/SKILL.md
+++ b/skills/nft-blockchain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nft-blockchain
-description: Display NFT artwork and interact with blockchain from Decentraland scenes. Show NFTs using NftShape with frame styles, check player wallet with getPlayer, sign messages with signedFetch, interact with smart contracts using eth-connect and createEthereumProvider, and handle MANA transactions. Use when user wants NFTs, blockchain, wallet, smart contracts, Web3, or crypto.
+description: NFT display and blockchain interaction in Decentraland. NftShape (framed NFT artwork), wallet checks (getPlayer, isGuest), signedFetch (authenticated requests), smart contract interaction (eth-connect, createEthereumProvider), and RPC calls. Use when the user wants NFTs, blockchain, wallet, smart contracts, Web3, crypto, or token gating. Do NOT use for player avatar data or emotes (see player-avatar).
 ---
 
 # NFT and Blockchain in Decentraland
@@ -11,7 +11,7 @@ Show an NFT from Ethereum in a decorative frame:
 
 ```typescript
 import { engine, Transform, NftShape, NftFrameType } from '@dcl/sdk/ecs'
-import { Vector3, Color4 } from '@dcl/sdk/math'
+import { Vector3, Quaternion, Color4 } from '@dcl/sdk/math'
 
 const nftFrame = engine.addEntity()
 Transform.create(nftFrame, {
@@ -86,20 +86,27 @@ Always check `isGuest` before attempting any blockchain interaction — guest pl
 Send authenticated requests to a backend, signed with the player's wallet:
 
 ```typescript
-import { signedFetch } from '@dcl/sdk/signed-fetch'
+import { signedFetch } from '~system/SignedFetch'
 
 executeTask(async () => {
   try {
-    const response = await signedFetch('https://example.com/api/action', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        action: 'claimReward',
-        amount: 100
-      })
+    const response = await signedFetch({
+      url: 'https://example.com/api/action',
+      init: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'claimReward',
+          amount: 100
+        })
+      }
     })
 
-    const result = await response.json()
+    if (!response.ok) {
+      console.error('HTTP error:', response.status)
+      return
+    }
+    const result = JSON.parse(response.body)
     console.log('Result:', result)
   } catch (error) {
     console.log('Request failed:', error)
@@ -108,26 +115,6 @@ executeTask(async () => {
 ```
 
 `signedFetch` automatically includes a cryptographic signature proving the player's identity. Your backend can verify this signature to authenticate requests.
-
-## MANA Transactions
-
-```typescript
-import { manaUser } from '@dcl/sdk/ethereum'
-
-executeTask(async () => {
-  try {
-    // Check MANA balance
-    const balance = await manaUser.balance()
-    console.log('MANA balance:', balance)
-
-    // Send MANA to another address
-    const result = await manaUser.send('0x123...abc', 100) // 100 MANA
-    console.log('MANA sent:', result)
-  } catch (error) {
-    console.log('MANA transaction failed:', error)
-  }
-})
-```
 
 ## Smart Contract Interaction
 

--- a/skills/optimize-scene/SKILL.md
+++ b/skills/optimize-scene/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: optimize-scene
-description: Optimize Decentraland scene performance, reduce entity count, minimize triangle budgets, improve loading times, and stay within scene limits. Use when user wants to optimize, improve performance, fix lag, reduce load time, or check scene limits.
+description: Optimize Decentraland scene performance. Scene limit formulas (triangles, entities, materials, textures, height per parcel count), object pooling, LOD patterns, texture optimization, system throttling, and asset preloading. Use when the user wants to optimize, improve performance, fix lag, reduce load time, check limits, or reduce entity/triangle count. Do NOT use for deployment (see deploy-scene).
 ---
 
 # Optimizing Decentraland Scenes
 
 ## Scene Limits (Per Parcel Count)
 
-| Parcels | Max Entities | Max Triangles | Max Textures | Max Materials | Max Height |
-|---------|-------------|---------------|-------------|--------------|-----------|
-| 1 | 512 | 10,000 | 10 MB | 20 | 20m |
-| 2 | 1,024 | 20,000 | 20 MB | 40 | 20m |
-| 4 | 2,048 | 40,000 | 40 MB | 80 | 20m |
-| 8 | 4,096 | 80,000 | 80 MB | 160 | 20m |
-| 16 | 8,192 | 160,000 | 160 MB | 320 | 20m |
+All limits scale with parcel count `n`. Triangles, entities, and bodies scale linearly. Materials, textures, and height scale logarithmically.
+
+| Resource | Formula | 1 parcel | 2 parcels | 4 parcels | 9 parcels | 16 parcels |
+|---|---|---|---|---|---|---|
+| **Triangles** | n x 10,000 | 10,000 | 20,000 | 40,000 | 90,000 | 160,000 |
+| **Entities** | n x 200 | 200 | 400 | 800 | 1,800 | 3,200 |
+| **Physics bodies** | n x 300 | 300 | 600 | 1,200 | 2,700 | 4,800 |
+| **Materials** | log2(n+1) x 20 | 20 | 31 | 46 | 66 | 81 |
+| **Textures** | log2(n+1) x 10 | 10 | 15 | 23 | 33 | 40 |
+| **Height limit** | log2(n+1) x 20m | 20m | 31m | 46m | 66m | 81m |
+
+**File limits:** 15 MB per parcel, 300 MB max total, 200 files per parcel, 50 MB max per individual file.
 
 ## Entity Count Optimization
 
@@ -93,11 +98,14 @@ MeshRenderer.setPlane(entity)  // Very cheap
 
 ## Texture Optimization
 
+- **Dimensions must be power-of-two**: 256, 512, 1024, 2048
+- **Recommended sizes**: 512x512 for most objects, 1024x1024 max for hero pieces
+- **Avoid textures over 2048x2048** — they consume excessive memory and often exceed limits
 - Use `.png` for UI/sprites with transparency
 - Use `.jpg` for photos and textures without transparency
-- Compress textures: 512x512 or 1024x1024 max for most use cases
-- Use texture atlases (combine multiple textures into one image)
-- Avoid 4096x4096 textures unless absolutely necessary
+- Prefer compressed formats (WebP) over raw PNG where possible
+- Use texture atlases (combine multiple textures into one image) to reduce draw calls and material count
+- Share texture references across materials — do not duplicate texture files
 - Reuse materials across entities:
 ```typescript
 // GOOD: Define material once, apply to many
@@ -142,13 +150,42 @@ engine.addSystem(systemFn)
 engine.removeSystem(systemFn)
 ```
 
+## Asset Preloading (AssetLoad Component)
+
+For large assets that would cause visible pop-in, use `AssetLoad` to pre-download before rendering:
+
+```typescript
+import { engine, AssetLoad, LoadingState, GltfContainer, Transform } from '@dcl/sdk/ecs'
+import { Vector3 } from '@dcl/sdk/math'
+
+// Create a preload entity at scene startup
+const preloadEntity = engine.addEntity()
+AssetLoad.create(preloadEntity, { src: 'models/large-model.glb' })
+
+// System to track loading progress
+function assetLoadingSystem(dt: number) {
+  for (const [entity] of engine.getEntitiesWith(AssetLoad)) {
+    const state = AssetLoad.get(entity)
+    if (state.loadingState === LoadingState.FINISHED) {
+      // Asset is cached — now safe to create the visible entity
+      GltfContainer.create(entity, { src: 'models/large-model.glb' })
+      Transform.create(entity, { position: Vector3.create(8, 0, 8) })
+      AssetLoad.deleteFrom(entity) // Remove preload component
+    }
+  }
+}
+engine.addSystem(assetLoadingSystem)
+```
+
+Use this pattern for any model over ~1 MB or for assets that should be ready before a game phase begins.
+
 ## Loading Time Optimization
 
 - Lazy-load 3D models (load on demand, not all at scene start)
 - Use compressed .glb files (Draco compression)
 - Minimize total asset size
 - Use CDN URLs for large shared assets when possible
-- Preload critical assets, defer non-essential ones
+- Preload critical assets with `AssetLoad`, defer non-essential ones
 
 ## Common Performance Pitfalls
 
@@ -158,3 +195,9 @@ engine.removeSystem(systemFn)
 4. **Uncompressed audio**: Use .mp3 instead of .wav for music (10x smaller).
 5. **Continuous raycasting**: Set `continuous: false` unless you need per-frame raycasting.
 6. **Text rendering**: `TextShape` is expensive. Use `Label` (UI) for text that doesn't need to be in 3D space.
+
+## Cross-References
+
+- **add-3d-models** — model loading, colliders, and file organization
+- **game-design** — performance budgets, design patterns, and MVP planning
+- **advanced-rendering** — texture modes, material reuse, and LOD with VisibilityComponent

--- a/skills/player-avatar/SKILL.md
+++ b/skills/player-avatar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: player-avatar
-description: Work with player avatars in Decentraland scenes. Read player position and profile data, customize appearance with AvatarBase, trigger emotes with triggerEmote/triggerSceneEmote, read equipped wearables via AvatarEquippedData, attach objects to players with AvatarAttach, create NPC avatars with AvatarShape, and modify avatars in areas. Use when user wants player data, emotes, wearables, avatar attachments, or NPCs.
+description: Player and avatar system in Decentraland. Read player position/profile, customize appearance (AvatarBase), trigger emotes (triggerEmote/triggerSceneEmote), read equipped wearables (AvatarEquippedData), attach objects to players (AvatarAttach), create NPC avatars (AvatarShape), avatar modifier areas, and locomotion settings. Use when the user wants player data, emotes, wearables, NPC avatars, avatar attachments, or movement speed changes. Do NOT use for wallet/blockchain interactions (see nft-blockchain).
 ---
 
 # Player and Avatar System in Decentraland
@@ -216,6 +216,20 @@ AvatarModifierArea.create(constraintArea, {
 })
 ```
 
+## Avatar Locomotion Settings
+
+Adjust the player's movement speed and jump height:
+
+```typescript
+import { engine, AvatarLocomotionSettings } from '@dcl/sdk/ecs'
+
+// Modify run speed and jump height
+AvatarLocomotionSettings.createOrReplace(engine.PlayerEntity, {
+  runSpeed: 8,    // default is ~6
+  jumpHeight: 3   // default is ~1.5
+})
+```
+
 ## Teleporting the Player
 
 **You MUST use `movePlayerTo` from `~system/RestrictedActions` to move or teleport the player.** Setting `Transform.getMutable(engine.PlayerEntity).position` does NOT work — the runtime ignores direct writes to the player transform.
@@ -268,6 +282,8 @@ Beyond the commonly used anchor points, the full list includes:
 - `AvatarAnchorPointType.AAPT_HEAD` — head bone
 - `AvatarAnchorPointType.AAPT_NECK` — neck bone
 
+> **Need to check the player's wallet before showing avatar items?** See the **nft-blockchain** skill for wallet checks with `getPlayer()` and `isGuest`.
+
 ## Best Practices
 
 - Always check `Transform.has(engine.PlayerEntity)` before reading player data — it may not be ready on the first frame
@@ -280,3 +296,4 @@ Beyond the commonly used anchor points, the full list includes:
 - `Transform.get(engine.PlayerEntity)` is valid for **reading** position only
 
 For component field details, see `{baseDir}/../../context/components-reference.md`.
+For full AvatarShape fields, wearable URNs, anchor points, emote names, and event callbacks, see `{baseDir}/references/avatar-apis.md`.

--- a/skills/player-avatar/references/avatar-apis.md
+++ b/skills/player-avatar/references/avatar-apis.md
@@ -1,0 +1,152 @@
+# Avatar APIs Reference
+
+## AvatarShape — Full Fields
+
+Create NPC avatars in your scene:
+
+```typescript
+import { AvatarShape } from '@dcl/sdk/ecs'
+
+AvatarShape.create(entity, {
+  id: 'npc-unique-id',          // Unique identifier (required)
+  name: 'NPC Name',             // Display name
+  bodyShape: 'urn:decentraland:off-chain:base-avatars:BaseMale',  // or BaseFemale
+  wearables: [                  // Array of wearable URNs
+    'urn:decentraland:off-chain:base-avatars:eyebrows_00',
+    'urn:decentraland:off-chain:base-avatars:mouth_00',
+    'urn:decentraland:off-chain:base-avatars:eyes_00',
+    'urn:decentraland:off-chain:base-avatars:blue_tshirt',
+    'urn:decentraland:off-chain:base-avatars:brown_pants',
+    'urn:decentraland:off-chain:base-avatars:classic_shoes',
+    'urn:decentraland:off-chain:base-avatars:short_hair'
+  ],
+  hairColor: { r: 0.92, g: 0.76, b: 0.62 },  // RGB 0-1
+  skinColor: { r: 0.94, g: 0.85, b: 0.6 },   // RGB 0-1
+  eyeColor: { r: 0.2, g: 0.4, b: 0.7 },      // RGB 0-1
+  expressionTriggerId: '',       // Currently playing expression
+  expressionTriggerTimestamp: 0, // When expression was triggered
+  talking: false,                // Mouth animation
+  emotes: [],                   // Custom emote URNs
+  show_only_wearables: false     // Mannequin mode (show wearables without body)
+})
+```
+
+### Body Shape URNs
+
+- `urn:decentraland:off-chain:base-avatars:BaseMale`
+- `urn:decentraland:off-chain:base-avatars:BaseFemale`
+
+### Common Base Wearable URNs
+
+**Required minimums (avatar won't render without face features):**
+- `urn:decentraland:off-chain:base-avatars:eyebrows_00` through `eyebrows_07`
+- `urn:decentraland:off-chain:base-avatars:mouth_00` through `mouth_04`
+- `urn:decentraland:off-chain:base-avatars:eyes_00` through `eyes_11`
+
+**Hair:**
+- `short_hair`, `long_hair`, `curly_hair`, `bald`, `mohawk`, `ponytail`, `cornrows`, `cool_hair`
+
+**Upper body:**
+- `blue_tshirt`, `red_tshirt`, `green_tshirt`, `black_tshirt`, `white_shirt`, `striped_shirt`, `elegant_sweater`
+
+**Lower body:**
+- `brown_pants`, `blue_jeans`, `cargo_pants`, `shorts`, `formal_pants`
+
+**Shoes:**
+- `classic_shoes`, `sport_shoes`, `elegant_shoes`, `sneakers`
+
+All base wearable URNs follow the pattern: `urn:decentraland:off-chain:base-avatars:<name>`
+
+### Mannequin Mode
+
+Display wearables without a full avatar body — useful for storefronts:
+
+```typescript
+AvatarShape.create(entity, {
+  id: 'mannequin-1',
+  name: 'Display',
+  wearables: ['urn:decentraland:matic:collections-v2:0x...:0'],
+  show_only_wearables: true
+})
+```
+
+## All Anchor Points
+
+```typescript
+import { AvatarAnchorPointType } from '@dcl/sdk/ecs'
+
+AvatarAnchorPointType.AAPT_POSITION    // Avatar root (feet)
+AvatarAnchorPointType.AAPT_NAME_TAG    // Above the name tag (head top)
+AvatarAnchorPointType.AAPT_LEFT_HAND   // Left hand bone
+AvatarAnchorPointType.AAPT_RIGHT_HAND  // Right hand bone
+AvatarAnchorPointType.AAPT_HEAD        // Head bone
+AvatarAnchorPointType.AAPT_NECK        // Neck bone
+```
+
+## Built-in Emote Names
+
+For `triggerEmote({ predefinedEmote: '...' })`:
+
+- `wave` — wave hello
+- `dance` — dance
+- `clap` — clap hands
+- `robot` — robot dance
+- `fistpump` — fist pump
+- `raiseHand` — raise hand
+- `shrug` — shrug shoulders
+- `headexplode` — head explode
+- `handsair` — hands in the air
+
+## Player Event Callbacks
+
+### Scene Entry/Exit
+
+```typescript
+import { onEnterScene, onLeaveScene } from '@dcl/sdk/src/players'
+
+onEnterScene((player) => {
+  console.log('Player entered:', player.userId)
+})
+
+onLeaveScene((userId) => {
+  console.log('Player left:', userId)
+})
+```
+
+### Avatar Change Listeners
+
+```typescript
+import { AvatarEmoteCommand, AvatarBase, AvatarEquippedData } from '@dcl/sdk/ecs'
+
+// Emote played
+AvatarEmoteCommand.onChange(engine.PlayerEntity, (cmd) => {
+  if (cmd) console.log('Emote:', cmd.emoteUrn)
+})
+
+// Appearance changed
+AvatarBase.onChange(engine.PlayerEntity, (base) => {
+  if (base) console.log('Name:', base.name, 'Body:', base.bodyShapeUrn)
+})
+
+// Equipment changed
+AvatarEquippedData.onChange(engine.PlayerEntity, (equipped) => {
+  if (equipped) console.log('Wearables:', equipped.wearableUrns)
+})
+```
+
+## AvatarModifierType — All Values
+
+```typescript
+AvatarModifierType.AMT_HIDE_AVATARS       // Hide all avatars in area
+AvatarModifierType.AMT_DISABLE_PASSPORTS  // Disable clicking avatars for profiles
+AvatarModifierType.AMT_DISABLE_JUMPING    // Prevent jumping in area
+```
+
+## AvatarLocomotionSettings
+
+```typescript
+AvatarLocomotionSettings.createOrReplace(engine.PlayerEntity, {
+  runSpeed: 8,     // Default ~6 m/s
+  jumpHeight: 3    // Default ~1.5m
+})
+```

--- a/skills/scene-runtime/SKILL.md
+++ b/skills/scene-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scene-runtime
-description: Scene runtime APIs — async tasks, HTTP fetch, WebSockets, realm/scene info, timers, restricted actions, portable experiences, testing framework
+description: Cross-cutting runtime APIs for Decentraland SDK7 scenes. Use when the user needs async operations (executeTask), HTTP requests (fetch, signedFetch), WebSocket connections, timers, realm/scene detection, restricted actions (movePlayerTo, teleportTo, triggerEmote, openExternalUrl), portable experiences, or the testing framework. Do NOT use for UI (see build-ui), multiplayer sync (see multiplayer-sync), or avatar/player data (see player-avatar).
 ---
 
 # Scene Runtime APIs
@@ -75,7 +75,7 @@ executeTask(async () => {
 ## World Time
 
 ```typescript
-import { getWorldTime } from '~system/EnvironmentApi'
+import { getWorldTime } from '~system/Runtime'
 
 executeTask(async () => {
   const { seconds } = await getWorldTime({})
@@ -255,3 +255,5 @@ npx @dcl/sdk-commands test
 - Check `realm.realmInfo?.isPreview` to detect preview mode and enable debug features
 - Use `readFile()` for data files (JSON configs, level data) deployed alongside the scene
 - `removeEntityWithChildren()` is essential when cleaning up complex entity hierarchies
+
+For complete executeTask patterns, all RestrictedActions, realm detection, and portable experiences, see `{baseDir}/references/runtime-apis.md`.

--- a/skills/scene-runtime/references/runtime-apis.md
+++ b/skills/scene-runtime/references/runtime-apis.md
@@ -1,0 +1,206 @@
+# Runtime APIs Reference
+
+## executeTask Patterns
+
+All async work must be wrapped in `executeTask()` — bare promises are silently dropped:
+
+```typescript
+import { executeTask } from '@dcl/sdk/ecs'
+
+// Basic async operation
+executeTask(async () => {
+  const res = await fetch('https://api.example.com/data')
+  const data = await res.json()
+  console.log(data)
+})
+
+// With error handling
+executeTask(async () => {
+  try {
+    const res = await fetch('https://api.example.com/data')
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json()
+    // Use data
+  } catch (error) {
+    console.error('Failed:', error)
+  }
+})
+
+// Sequential async operations
+executeTask(async () => {
+  const config = await loadConfig()
+  const data = await fetchData(config.apiUrl)
+  initializeScene(data)
+})
+```
+
+## All Restricted Actions
+
+Import from `~system/RestrictedActions`. These require prior player interaction (e.g., a click) before they execute.
+
+### movePlayerTo
+Move the player to a position within scene bounds:
+```typescript
+import { movePlayerTo } from '~system/RestrictedActions'
+
+movePlayerTo({
+  newRelativePosition: { x: 8, y: 0, z: 8 },
+  cameraTarget: { x: 8, y: 1, z: 12 }  // Optional: where camera looks
+})
+```
+
+### teleportTo
+Teleport to Genesis City coordinates:
+```typescript
+import { teleportTo } from '~system/RestrictedActions'
+teleportTo({ worldCoordinates: { x: 50, y: 70 } })
+```
+
+### triggerEmote
+Play a built-in avatar emote:
+```typescript
+import { triggerEmote } from '~system/RestrictedActions'
+triggerEmote({ predefinedEmote: 'wave' })
+// Available: 'wave', 'dance', 'clap', 'robot', 'fistpump', 'raiseHand', etc.
+```
+
+### triggerSceneEmote
+Play a custom emote from a .glb file (must end with `_emote.glb`):
+```typescript
+import { triggerSceneEmote } from '~system/RestrictedActions'
+triggerSceneEmote({ src: 'animations/custom_emote.glb', loop: false })
+```
+
+### openExternalUrl
+Open a URL in the player's browser (shows confirmation prompt):
+```typescript
+import { openExternalUrl } from '~system/RestrictedActions'
+openExternalUrl({ url: 'https://decentraland.org' })
+```
+
+### openNftDialog
+Show an NFT detail dialog:
+```typescript
+import { openNftDialog } from '~system/RestrictedActions'
+openNftDialog({ urn: 'urn:decentraland:ethereum:erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d:558536' })
+```
+
+### copyToClipboard
+Copy text to the player's clipboard:
+```typescript
+import { copyToClipboard } from '~system/RestrictedActions'
+copyToClipboard({ value: 'Hello from Decentraland!' })
+```
+
+### changeRealm
+Prompt the player to switch to a different realm:
+```typescript
+import { changeRealm } from '~system/RestrictedActions'
+changeRealm({ realm: 'other-realm.dcl.eth', message: 'Join this realm?' })
+```
+
+### setCommunicationsAdapter
+Change the communications adapter for the scene:
+```typescript
+import { setCommunicationsAdapter } from '~system/RestrictedActions'
+setCommunicationsAdapter({ adapter: 'wss://custom-comms.example.com' })
+```
+
+## Realm Detection Patterns
+
+```typescript
+import { getRealm } from '~system/Runtime'
+
+executeTask(async () => {
+  const realm = await getRealm({})
+  const info = realm.realmInfo
+
+  // Check if running in preview
+  if (info?.isPreview) {
+    console.log('Running in preview mode')
+  }
+
+  // Get realm name and network
+  console.log('Realm:', info?.realmName)      // e.g., "peer-us-1"
+  console.log('Network:', info?.networkId)     // 1 = mainnet, 5 = goerli
+  console.log('Base URL:', info?.baseUrl)
+  console.log('Comms:', info?.commsAdapter)
+})
+```
+
+### Common Pattern: Preview-Only Debug Features
+
+```typescript
+executeTask(async () => {
+  const realm = await getRealm({})
+  if (realm.realmInfo?.isPreview) {
+    enableDebugPanel()
+    enableFreeCam()
+  }
+})
+```
+
+## Scene Information
+
+```typescript
+import { getSceneInformation } from '~system/Runtime'
+
+executeTask(async () => {
+  const scene = await getSceneInformation({})
+  const metadata = JSON.parse(scene.metadataJson)
+
+  console.log('URN:', scene.urn)
+  console.log('Base URL:', scene.baseUrl)
+  console.log('Parcels:', metadata.scene?.parcels)
+  console.log('Title:', metadata.display?.title)
+})
+```
+
+## Read Deployed Files
+
+Read data files shipped with the scene:
+
+```typescript
+import { readFile } from '~system/Runtime'
+
+executeTask(async () => {
+  const result = await readFile({ fileName: 'data/config.json' })
+  const text = new TextDecoder().decode(result.content)
+  const config = JSON.parse(text)
+})
+```
+
+## Portable Experiences
+
+Scenes that persist across world navigation:
+
+```typescript
+import { spawn, kill, exit, getPortableExperiencesLoaded } from '~system/PortableExperiences'
+
+// Spawn by URN
+const result = await spawn({ urn: 'urn:decentraland:entity:bafk...' })
+
+// List loaded portable experiences
+const loaded = await getPortableExperiencesLoaded({})
+
+// Kill a specific one
+await kill({ urn: 'urn:decentraland:entity:bafk...' })
+
+// Exit self (if this IS a portable experience)
+await exit({})
+```
+
+## CommsAdapter
+
+Custom communication channels between players:
+
+```typescript
+import { setCommunicationsAdapter } from '~system/RestrictedActions'
+
+// Switch to a custom WebSocket-based comms adapter
+setCommunicationsAdapter({
+  adapter: 'wss://custom-comms-server.example.com/room/my-scene'
+})
+```
+
+Used for custom multiplayer infrastructure beyond the default CRDT sync.

--- a/skills/visual-feedback/SKILL.md
+++ b/skills/visual-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: visual-feedback
-description: Use the screenshot tool to see the running Decentraland preview and verify scene changes visually. Use when the preview is running and you need to check what the scene looks like after making code changes.
+description: Capture screenshots of the running Decentraland preview to verify scene changes visually. Covers camera movement, interaction actions, and visual debugging. Use when the preview is running and you need to check what the scene looks like, debug visual issues, or verify layout. Do NOT use for code changes (make changes first, then screenshot).
 ---
 
 # Visual Feedback — Seeing Your Scene
@@ -102,6 +102,21 @@ Keep it to 1-2 screenshots per task. Each screenshot consumes significant tokens
 | Scene looks different after code change | Hot reload takes ~1-2s — add a `wait` action of 2000ms |
 | "No preview server running" | Start it with `/preview` first |
 | Empty/gray space, no scene content | You've left the scene boundaries — stop moving |
+| Z-fighting (flickering surfaces) | Two surfaces at the same position | Move one surface slightly (0.01m) away from the other |
+| Missing textures (pink/magenta) | Texture file not found or wrong path | Verify file exists in project and path matches code |
+| Objects appear wrong scale | Scale values off or model exported at wrong scale | Check Transform.scale values; 1,1,1 is original model size |
+| Lighting looks flat | No LightSource components in scene | Add point or spot lights — see **lighting-environment** skill |
+
+## What to Look For in Screenshots
+
+When evaluating a screenshot, check these common issues:
+
+- **Missing objects** — entity exists in code but not visible. Check: wrong position (behind camera, underground, outside parcels), scale of 0, VisibilityComponent set to false
+- **Z-fighting** — flickering or shimmering where two surfaces overlap. Fix: offset one surface by 0.01m
+- **Texture issues** — pink/magenta means missing texture file, black means missing material, white means missing texture coordinates
+- **Scale problems** — objects too large (clipping through ceiling) or too small (invisible dots). Compare against parcel size (16m x 16m)
+- **Lighting** — very flat/uniform usually means no custom lights. Dark scene may need SkyboxTime adjustment
+- **UI elements** — check that HUD elements are positioned correctly and text is readable
 
 ## Tips
 

--- a/tests/integration/dcl-header.test.ts
+++ b/tests/integration/dcl-header.test.ts
@@ -90,10 +90,10 @@ describe("dcl-header", () => {
       expect(names).toEqual([]);
     });
 
-    it("reads real skills directory and finds all 19 skills", () => {
+    it("reads real skills directory and finds all 20 skills", () => {
       const realSkillsDir = join(import.meta.dirname, "../../skills");
       const names = getSkillNames(realSkillsDir);
-      expect(names.length).toBe(19);
+      expect(names.length).toBe(20);
       expect(names).toContain("create-scene");
       expect(names).toContain("add-3d-models");
       expect(names).toContain("deploy-worlds");

--- a/tests/unit/skills/skill-loading.test.ts
+++ b/tests/unit/skills/skill-loading.test.ts
@@ -110,6 +110,8 @@ describe("skill loading", () => {
       "advanced-input",
       "authoritative-server",
       "scene-runtime",
+      "game-design",
+      "visual-feedback",
     ];
     for (const name of expected) {
       expect(names, `Missing skill: ${name}`).toContain(name);


### PR DESCRIPTION
## Summary

Comprehensive quality pass across all 20 skills following Anthropic's skill guide principles:

- **API accuracy**: Verified all code examples against `js-sdk-toolchain` source — fixed `signedFetch` calling convention (takes `{url, init}` object, returns `FlatFetchResponse`), `SkyboxTime` field names (`fixedTime`/`transitionMode`), `Tween.setMove/setRotate/setScale` signatures (entity as first arg, returns void), `EasingFunction` enum names (`EF_EASEQUAD` not `EF_EASEINOUTQUAD`), `getWorldTime` import (`~system/Runtime`), `onEnterScene/onLeaveScene` from `@dcl/sdk/src/players`
- **Structural improvements**: Added decision trees to 4 skills, error→cause→solution troubleshooting to 8 skills, QuickJS sandbox caveats, cross-references between related skills
- **Progressive disclosure**: Created 8 reference files extracting deep API docs from SKILL.md bodies
- **Descriptions**: Rewrote all 20 with trigger phrases and negative triggers for better skill selection
- **Bug fixes**: Trailing comma in deploy-scene JSON, `GltfNode`→`GltfNodeModifiers` in advanced-rendering

## What could break

- Skills that previously used `EF_EASEINOUTSINE` now correctly use `EF_EASESINE` — generated scenes using old enum names would fail to compile
- `signedFetch` examples now use the object form `signedFetch({ url, init })` instead of `signedFetch(url, opts)` — scenes generated from old skills would get runtime errors
- `onEnterScene`/`onLeaveScene` now imported from `@dcl/sdk/src/players` instead of deprecated `@dcl/sdk/observables`

## How to test

- `npm test` — all 441 tests pass
- Verify descriptions are under 1024 chars: `grep -c '' skills/*/SKILL.md` + check frontmatter
- Spot-check code examples against [js-sdk-toolchain](https://github.com/decentraland/js-sdk-toolchain) source
- Create a test scene using the agent and verify generated code compiles