### PR TITLE
Remove permission gate for read-only operations outside cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The result: **more creators building more scenes, faster.**
 - **Integrated commands** — `/init` to scaffold, `/preview` to launch the dev server, `/tasks` to manage running processes, `/review` to audit code
 - **TypeScript validation** — catches type errors immediately after writing code
 - **Free asset catalogs** — 2,700+ Creator Hub 3D models, 900+ CC0-licensed models, and 50 audio files the agent proactively suggests when building scenes
-- **Permission gate** — prompts for confirmation before destructive bash commands, writes to sensitive files, or any file access outside the working directory
+- **Permission gate** — prompts for confirmation before destructive bash commands, writes to sensitive files, or writes/edits outside the working directory
 - **Compact tool output** — write shows path + size instead of file content, read shows a 5-line preview instead of 10
 - **Session persistence** — pick up where you left off across sessions
 

--- a/extensions/permissions/index.ts
+++ b/extensions/permissions/index.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
-import { classifyBashCommand, classifyFilePath, isOutsideCwd, OUTSIDE_CWD_REASON } from "./utils.js";
+import { classifyBashCommand, classifyFilePath, OUTSIDE_CWD_REASON } from "./utils.js";
 import { resolve } from "node:path";
 
 type BlockResult = { block: true; reason: string };
@@ -91,17 +91,6 @@ const extension: ExtensionFactory = (pi) => {
       return promptOrBlock(ctx, reason, `Path: ${filePath}`, () => sessionAllow.add(reason));
     }
 
-    if (toolName === "read" || toolName === "grep" || toolName === "find" || toolName === "ls") {
-      const filePath = (event.input as { path?: string }).path ?? "";
-      if (!filePath) return;
-
-      const resolved = resolve(ctx.cwd, filePath);
-      const reason = isOutsideCwd(filePath, ctx.cwd);
-      if (!reason) return;
-      if (isPathAllowed(resolved)) return;
-
-      return promptOrBlock(ctx, reason, `Path: ${filePath}`, () => allowedPaths.add(resolved));
-    }
   });
 };
 

--- a/tests/integration/permissions.test.ts
+++ b/tests/integration/permissions.test.ts
@@ -231,28 +231,14 @@ describe("permissions extension", () => {
       expect(wasSelectCalled()).toBe(false);
     });
 
-    it("blocks reads outside cwd when user denies", async () => {
+    it("allows reads outside cwd without prompting", async () => {
+      const { ctx, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
       const result = await toolCallHandler(
         { toolName: "read", input: { path: "/etc/passwd" } },
-        selectingContext("Deny", { cwd: PROJECT_ROOT }),
-      );
-      expect(result).toEqual(expect.objectContaining({ block: true }));
-    });
-
-    it("allows reads outside cwd when user accepts", async () => {
-      const result = await toolCallHandler(
-        { toolName: "read", input: { path: "/etc/passwd" } },
-        selectingContext("Allow", { cwd: PROJECT_ROOT }),
+        ctx,
       );
       expect(result).toBeUndefined();
-    });
-
-    it("blocks reads outside cwd in non-interactive mode", async () => {
-      const result = await toolCallHandler(
-        { toolName: "read", input: { path: "/etc/passwd" } },
-        createMockContext({ hasUI: false, cwd: PROJECT_ROOT }),
-      );
-      expect(result).toEqual(expect.objectContaining({ block: true }));
+      expect(wasSelectCalled()).toBe(false);
     });
 
     it("allows reads with no path (defaults to cwd)", async () => {
@@ -276,69 +262,15 @@ describe("permissions extension", () => {
         expect(wasSelectCalled()).toBe(false);
       });
 
-      it(`${toolName}: prompts for paths outside cwd`, async () => {
+      it(`${toolName}: allows paths outside cwd without prompting`, async () => {
+        const { ctx, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
         const result = await toolCallHandler(
           { toolName, input: { path: "/tmp/other" } },
-          selectingContext("Deny", { cwd: PROJECT_ROOT }),
+          ctx,
         );
-        expect(result).toEqual(expect.objectContaining({ block: true }));
+        expect(result).toBeUndefined();
+        expect(wasSelectCalled()).toBe(false);
       });
     }
-  });
-
-  describe("path-scoped session permissions", () => {
-    const PROJECT_ROOT = "/home/user/project";
-
-    it("'Always allow' auto-allows re-read of same path", async () => {
-      // Allow /etc/passwd with "Always allow"
-      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
-      await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx1);
-
-      // Re-read /etc/passwd → auto-allowed
-      const { ctx: ctx2, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
-      const result = await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx2);
-
-      expect(result).toBeUndefined();
-      expect(wasSelectCalled()).toBe(false);
-    });
-
-    it("'Always allow' for one path does NOT auto-allow a different path", async () => {
-      // Allow /etc/passwd
-      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
-      await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx1);
-
-      // /tmp/file.txt is different → still prompts
-      const result = await toolCallHandler(
-        { toolName: "read", input: { path: "/tmp/file.txt" } },
-        selectingContext("Deny", { cwd: PROJECT_ROOT }),
-      );
-      expect(result).toEqual(expect.objectContaining({ block: true }));
-    });
-
-    it("'Always allow' for directory auto-allows files under it (prefix match)", async () => {
-      // Allow /etc
-      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
-      await toolCallHandler({ toolName: "read", input: { path: "/etc" } }, ctx1);
-
-      // /etc/passwd is under /etc → auto-allowed
-      const { ctx: ctx2, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
-      const result = await toolCallHandler({ toolName: "read", input: { path: "/etc/passwd" } }, ctx2);
-
-      expect(result).toBeUndefined();
-      expect(wasSelectCalled()).toBe(false);
-    });
-
-    it("'Always allow' on read covers write/edit to same outside-cwd path", async () => {
-      // Allow /tmp/shared.ts via read
-      const ctx1 = selectingContext("Always allow", { cwd: PROJECT_ROOT });
-      await toolCallHandler({ toolName: "read", input: { path: "/tmp/shared.ts" } }, ctx1);
-
-      // Write to /tmp/shared.ts → same allowedPaths → auto-allowed
-      const { ctx: ctx2, wasSelectCalled } = spyingContext({ cwd: PROJECT_ROOT });
-      const result = await toolCallHandler({ toolName: "write", input: { path: "/tmp/shared.ts" } }, ctx2);
-
-      expect(result).toBeUndefined();
-      expect(wasSelectCalled()).toBe(false);
-    });
   });
 });


### PR DESCRIPTION
## Summary
- Remove the confirmation prompt for read, grep, find, and ls operations targeting paths outside the working directory
- Only writes/edits outside cwd are now gated — read-only operations are harmless and the prompts created unnecessary friction
- Clean up unused `isOutsideCwd` import and replace "blocks reads" tests with "allows reads without prompting" tests

## What could break
- Agents can now read any file on the filesystem without confirmation. This is intentional — the previous gate provided no meaningful security since the agent could already read via bash commands.

## How to test
- `npm test` — all 435 tests pass
- Run opendcl and try reading a file outside the project directory (e.g. `/etc/hosts`) — should proceed without prompting
- Try writing outside cwd — should still prompt for confirmation