### PR TITLE
Add visit URL to deploy success message

### DIFF
--- a/extensions/dcl-deploy.ts
+++ b/extensions/dcl-deploy.ts
@@ -13,15 +13,28 @@ import { join } from "node:path";
 import { fileExists, findSceneRoot } from "./scene-utils.js";
 
 const WORLDS_CONTENT_SERVER = "https://worlds-content-server.decentraland.org";
+const BEVY_BASE = "https://decentraland.zone/bevy-web";
 
-async function hasWorldConfiguration(sceneRoot: string): Promise<boolean> {
+interface SceneDeployInfo {
+  /** World name (e.g. "boedo.dcl.eth") — presence means it's a World deploy */
+  worldName?: string;
+  /** Base parcel (e.g. "30,30") for Genesis City */
+  baseParcel?: string;
+}
+
+async function getSceneDeployInfo(sceneRoot: string): Promise<SceneDeployInfo> {
   try {
     let content = await readFile(join(sceneRoot, "scene.json"), "utf-8");
     if (content.charCodeAt(0) === 0xfeff) content = content.slice(1);
     const sceneJson = JSON.parse(content);
-    return Boolean(sceneJson.worldConfiguration?.name);
+    const worldName = sceneJson.worldConfiguration?.name;
+    if (worldName) {
+      return { worldName };
+    }
+    const baseParcel = sceneJson.scene?.base;
+    return { baseParcel };
   } catch {
-    return false;
+    return {};
   }
 }
 
@@ -39,13 +52,14 @@ async function deployScene(
     return { message: "node_modules not found. Run 'npm install' first.", isError: true };
   }
 
-  const isWorldDeploy = await hasWorldConfiguration(sceneRoot);
+  const deployInfo = await getSceneDeployInfo(sceneRoot);
+  const isWorld = Boolean(deployInfo.worldName);
   const deployArgs = ["@dcl/sdk-commands", "deploy"];
-  if (isWorldDeploy) {
+  if (isWorld) {
     deployArgs.push("--target-content", WORLDS_CONTENT_SERVER);
   }
 
-  const targetLabel = isWorldDeploy ? "World" : "Genesis City";
+  const targetLabel = isWorld ? "World" : "Genesis City";
 
   try {
     const result = await pi.exec("npx", deployArgs, {
@@ -54,7 +68,14 @@ async function deployScene(
     });
 
     if (result.code === 0) {
-      return { message: `Scene deployed to ${targetLabel} successfully!` };
+      let visitUrl: string | undefined;
+      if (deployInfo.worldName) {
+        visitUrl = `${BEVY_BASE}?realm=${deployInfo.worldName}`;
+      } else if (deployInfo.baseParcel) {
+        visitUrl = `${BEVY_BASE}?position=${deployInfo.baseParcel}`;
+      }
+      const urlLine = visitUrl ? `\nVisit: ${visitUrl}` : "";
+      return { message: `Scene deployed to ${targetLabel} successfully!${urlLine}` };
     } else {
       return { message: `Deploy failed (exit code ${result.code}): ${result.stderr || result.stdout}`, isError: true };
     }

--- a/skills/deploy-worlds/SKILL.md
+++ b/skills/deploy-worlds/SKILL.md
@@ -65,13 +65,11 @@ This will prompt the user to sign the deployment with their wallet. Validations 
 
 ## 3. Access the World
 
-Once deployed, the World is accessible at:
+After a successful deploy, the `/deploy` command outputs a visit URL automatically. The World is also accessible at:
 
 ```
-decentraland://?realm=NAME.dcl.eth
+https://decentraland.zone/bevy-web?realm=NAME.dcl.eth
 ```
-
-Replace `NAME` with the Decentraland NAME or ENS domain used for deployment.
 
 From inside Decentraland, use the chatbox command:
 ```


### PR DESCRIPTION
## Summary
- Replace `hasWorldConfiguration()` boolean with `getSceneDeployInfo()` that extracts world name and base parcel from `scene.json`
- After successful deploy, show a bevy-web visit URL so users can immediately open their scene
- World deploys: `https://decentraland.zone/bevy-web?realm=<worldName>`
- Genesis City deploys: `https://decentraland.zone/bevy-web?position=<baseParcel>`

## What could break
- The visit URL depends on `decentraland.zone/bevy-web` being accessible — if the domain changes, the URL will be stale
- If `scene.json` has no `worldConfiguration.name` and no `scene.base`, no URL is shown (graceful fallback)

## How to test
- Deploy a World scene → verify the success message includes `Visit: https://decentraland.zone/bevy-web?realm=<name>`
- Deploy a Genesis City scene → verify URL uses `?position=<base>`
- Deploy a scene with missing metadata → verify no URL line appears
- `npm run lint` and `npm test` both pass