### PR TITLE
Support ANTHROPIC_BASE_URL for API proxy routing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,19 @@
  */
 
 import { main, InteractiveMode } from "@mariozechner/pi-coding-agent";
+import { getModels } from "@mariozechner/pi-ai";
 import { isDev } from "./utils.js";
+
+// Allow overriding the Anthropic API base URL via env var.
+// Used by opendcl-studio's API proxy to keep the real API key out of sandbox containers.
+// getModels() returns references to the same model objects used by the provider,
+// so mutating baseUrl here affects all subsequent API calls.
+const anthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+if (anthropicBaseUrl) {
+  for (const model of getModels("anthropic")) {
+    (model as unknown as { baseUrl: string }).baseUrl = anthropicBaseUrl;
+  }
+}
 import { getCompactToolDefinition } from "./compact-tool-renderers.js";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";


### PR DESCRIPTION
## Summary
- When `ANTHROPIC_BASE_URL` env var is set, patch all Anthropic model `baseUrl` at startup
- Allows opendcl-studio to route API calls through a server-side proxy, keeping the real API key out of sandbox containers
- Uses `getModels("anthropic")` from pi-ai's public API — returns mutable references, so the mutation affects all subsequent API calls
- No effect when env var is not set (default behavior unchanged)

## What could break
- If pi-ai changes `getModels()` to return copies instead of references, the patch won't work

## How to test
```bash
ANTHROPIC_BASE_URL=http://localhost:3001/proxy ANTHROPIC_API_KEY=test opendcl --mode rpc --headless
# SDK will send requests to http://localhost:3001/proxy/v1/messages instead of api.anthropic.com
```