### PR TITLE
Preview thumbnails for model picks + richer preview exit errors

### DIFF
--- a/extensions/dcl-preview.ts
+++ b/extensions/dcl-preview.ts
@@ -87,9 +87,18 @@ const extension: ExtensionFactory = (pi) => {
       updateStatus(ctx);
 
       let bevyUrlFound = false;
+      const recentOutput: string[] = [];
+      const MAX_RECENT_LINES = 50;
 
       function handleOutput(data: Buffer): void {
         const output = data.toString().trim();
+        if (!output) return;
+
+        for (const line of output.split("\n")) {
+          recentOutput.push(line);
+          if (recentOutput.length > MAX_RECENT_LINES) recentOutput.shift();
+        }
+
         if (output.includes("EADDRINUSE") || output.includes("address already in use")) {
           ctx.ui.notify("Port already in use. Try /tasks to stop existing servers.", "error");
           return;
@@ -118,7 +127,8 @@ const extension: ExtensionFactory = (pi) => {
 
       previewProcess.on("exit", (code) => {
         if (code !== 0 && code !== null) {
-          ctx.ui.notify(`Preview server exited with code ${code}`, "warning");
+          const errorContext = recentOutput.length > 0 ? `\n${recentOutput.join("\n")}` : "";
+          ctx.ui.notify(`Preview server exited with code ${code}${errorContext}`, "warning");
         }
         cleanupPreview();
         updateStatus(ctx);

--- a/prompts/system.md
+++ b/prompts/system.md
@@ -112,8 +112,9 @@ scene-project/
 - Don't start the preview server automatically after writing code. The user will type `/preview` when ready.
 - **Proactively suggest 3D assets**: When building a scene, search the model catalog for free models that match the user's theme:
   - `skills/add-3d-models/references/model-catalog.md` — 5,700+ optimized 3D models (characters, structures, props, nature, vehicles, effects, etc.)
-  - Search with `grep -i "keyword" skills/add-3d-models/references/model-catalog.md`, fetch the preview thumbnail to confirm, then download with curl.
-  - Download matching models with `curl -o models/filename.glb "URL"` before referencing them in code.
+  - Search with `grep -i "keyword" skills/add-3d-models/references/model-catalog.md`.
+  - **Always show preview thumbnails** when presenting model options: download each candidate's `preview:` URL to `/tmp/` with `curl -s -o /tmp/name-preview.png "URL"`, then use the Read tool to display it inline. This lets the user visually compare and choose the right model.
+  - Once the user picks a model, download with `curl -o models/filename.glb "URL"` before referencing them in code.
 
 ### Visual Iteration Workflow
 

--- a/skills/add-3d-models/SKILL.md
+++ b/skills/add-3d-models/SKILL.md
@@ -127,21 +127,36 @@ grep "^##\|chair" {baseDir}/references/model-catalog.md
 
 1. Search the catalog with different keywords until you find matching models
 2. Review the results — check dimensions, triangle count, animations, and description
-3. Download the model with the curl command into `models/`
-4. Reference in code with `GltfContainer.create(entity, { src: 'models/{slug}.glb' })`
-5. If the model has animations (listed in `[anim: ...]`), use the `Animator` component to play them
-6. After placing the model, you can fetch its **preview thumbnail** (`preview:` URL) to see what it looks like
+3. **Show preview thumbnails** so the user can choose: download each candidate's `preview:` URL to a temp file with curl, then use the Read tool to display it as an image
+4. Once the user picks a model, download the `.glb` with the curl command into `models/`
+5. Reference in code with `GltfContainer.create(entity, { src: 'models/{slug}.glb' })`
+6. If the model has animations (listed in `[anim: ...]`), use the `Animator` component to play them
+
+### Showing preview thumbnails
+
+When presenting model options, **always show the thumbnail image** for each candidate so the user can visually compare. Each catalog entry has a `preview:` URL pointing to a PNG thumbnail.
+
+```bash
+# Download thumbnail to a temp file
+curl -s -o /tmp/model-preview.png "PREVIEW_URL"
+```
+
+Then use the **Read tool** on the downloaded file to display it inline. Show one thumbnail per model with its name, triangle count, and animations listed.
 
 ### Example workflow
 ```bash
-# Search for zombie models
+# 1. Search for zombie models
 grep -i "zombie" {baseDir}/references/model-catalog.md
 
-# Found: zombie-purple | 2.8×2.9×0.5m | 1472 tri | 271KB | character/zombie | ...
+# 2. Found: zombie-purple | 2.8×2.9×0.5m | 1472 tri | 271KB | character/zombie | ...
 #   [anim: Tpose, ZombieAttack, ZombieUP, ZombieWalk]
 #   preview: https://models.dclregenesislabs.xyz/blobs/bafkrei...
 
-# Download the model
+# 3. Download and show thumbnails for the user to pick
+curl -s -o /tmp/zombie-purple-preview.png "https://models.dclregenesislabs.xyz/blobs/bafkrei..."
+# Then: Read /tmp/zombie-purple-preview.png (displays image inline)
+
+# 4. User picks a model → download the .glb
 curl -o models/zombie-purple.glb "https://models.dclregenesislabs.xyz/blobs/bafybeiffc..."
 ```
 


### PR DESCRIPTION
## Summary

Two small quality-of-life improvements:

- **Show 3D model thumbnails before picking**: The `add-3d-models` skill and system prompt now instruct the agent to `curl` each candidate's `preview:` PNG and display it inline via the Read tool, so users can visually compare options instead of guessing from catalog metadata.
- **Include recent output in preview exit warning**: `dcl-preview` now keeps a 50-line ring buffer of the preview server's stdout/stderr and appends it to the exit warning when the server dies with a non-zero code — so the failure cause is visible without opening `/tasks`.

## What could break

- Thumbnail downloads hit `models.dclregenesislabs.xyz` once per candidate. If the CDN is unreachable the agent will fail the curl and should fall back to picking by metadata; worst case the user just doesn't see previews.
- The exit warning can now be up to ~50 lines long; verbose enough that it might look noisy in the UI but still bounded.
- No behavior change when the preview server exits cleanly (code 0 or null).

## How to test

- [ ] `npm test` — all tests pass
- [ ] `npm run lint` — clean
- [ ] Run `/preview` on a broken scene, kill the server, verify the warning now contains the last lines of output
- [ ] Ask the agent to "add a zombie to the scene" — verify it downloads and displays preview thumbnails before asking you to pick