### PR TITLE
Switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -15,7 +15,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
       - uses: decentraland/oddish-action@master
         with:
           deterministic-snapshot: true
@@ -29,5 +30,3 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           access: public
           provenance: false
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump Node to 24 — its bundled npm is ≥ 11.5.1, the floor for OIDC trusted publisher auto-detection
- Move `registry-url` onto `setup-node` so the OIDC flow knows the target registry
- Drop `NODE_AUTH_TOKEN: NPM_TOKEN` from the publish step — with OIDC, npm mints a short-lived token from the GitHub-issued ID token, and a static token would override that

Requires a one-time setup on npmjs.com: in the package settings, add a Trusted Publisher pointing at `dcl-regenesislabs/opendcl`, workflow filename `build-release.yaml`, no environment.

`permissions.id-token: write` is already set on the job.

## What could break
- If `decentraland/oddish-action` strips the OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) or injects its own auth token, publish will fail with 401/403. Fallback: replace the action with a plain `npm publish --access public` step.
- If the Trusted Publisher isn't configured on npmjs.com before this merges, the first release after merge will fail to publish.
- Node 22 → 24 for this job. The build/test scripts run under the newer Node — watch for postinstall or build scripts pinned to older Node.

## How to test
- [ ] Configure the Trusted Publisher on npmjs.com (org dcl-regenesislabs, repo opendcl, workflow build-release.yaml)
- [ ] Merge to main and watch the next Build and release run — confirm publish succeeds without NPM_TOKEN
- [ ] Verify the new version appears on npmjs.com