### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
   ],
   "author": "Decentraland",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dcl-regenesislabs/opendcl.git"
+  },
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.54.0",
     "playwright-core": "^1.58.2"


### PR DESCRIPTION
## Summary
The first publish after switching to OIDC trusted publishing failed with `E422 Unprocessable Entity — Error verifying sigstore provenance bundle`. npm 11.5+ generates a provenance statement that embeds the GitHub repo URL, and it refuses to publish if `package.json` doesn't declare a matching `repository.url`.

Run: https://github.com/dcl-regenesislabs/opendcl/actions/runs/26165030155

Also worth noting: the `provenance: false` we left in the workflow is being silently ignored — once OIDC is detected, provenance is mandatory. We can clean that flag up in a follow-up.

## What could break
- None expected. Adding `repository` is a metadata-only change.

## How to test
- [ ] Merge and watch the next Build and release run — confirm the publish step now succeeds
- [ ] On the published package page, verify the GitHub repo link and provenance badge appear