### PR TITLE
Editor coexists with scene click handlers and UI

### DIFF
--- a/skills/editor-gizmo/src/__editor/discovery.ts
+++ b/skills/editor-gizmo/src/__editor/discovery.ts
@@ -9,7 +9,9 @@ import {
   Material,
   GltfContainer,
   Name,
-  pointerEventsSystem,
+  PointerEvents,
+  PointerEventType,
+  inputSystem,
   InputAction,
   ColliderLayer,
 } from '@dcl/sdk/ecs'
@@ -30,6 +32,22 @@ export const SKIP_ENTITIES = new Set<Entity>()
 
 /** Entity names to skip (case-insensitive). Add names here to prevent selection. */
 const SKIP_NAMES = new Set(['ground', 'floor'])
+
+type PointerEventsValue = ReturnType<typeof PointerEvents.get>
+const originalPointerEvents = new Map<Entity, PointerEventsValue | null>()
+
+function addEditorHover(entity: Entity, name: string) {
+  const existing = PointerEvents.getMutableOrNull(entity)
+  const entry = {
+    eventType: PointerEventType.PET_DOWN,
+    eventInfo: { button: InputAction.IA_POINTER, hoverText: `Select ${name}`, maxDistance: 100 },
+  }
+  if (existing) {
+    existing.pointerEvents.push(entry)
+  } else {
+    PointerEvents.create(entity, { pointerEvents: [entry] })
+  }
+}
 
 function getEntityName(entity: Entity): string {
   if (Name.has(entity)) {
@@ -142,16 +160,9 @@ export function registerEntity(entity: Entity) {
 
   selectableInfoMap.set(entity, info)
 
-  pointerEventsSystem.onPointerDown(
-    {
-      entity,
-      opts: { button: InputAction.IA_POINTER, hoverText: `Select ${name}`, maxDistance: 100 },
-    },
-    () => {
-      if (!state.editorActive || state.isDragging || gizmoClickConsumed) return
-      selectEntity(entity)
-    }
-  )
+  const snapshot = PointerEvents.getOrNull(entity)
+  originalPointerEvents.set(entity, snapshot ? structuredClone(snapshot) : null)
+  addEditorHover(entity, name)
 }
 
 export function discoverySystem() {
@@ -165,22 +176,35 @@ export function discoverySystem() {
   }
 }
 
-/** Remove pointer events from all discovered entities (hides hover text). */
-export function removeAllPointerEvents() {
+/** Polls pointer-down input per selectable entity. Runs only while editor is
+ *  active so scene click handlers behave normally otherwise. */
+export function editorClickSystem() {
+  if (!state.editorActive || state.isDragging || gizmoClickConsumed) return
   for (const [entity] of selectableInfoMap) {
-    pointerEventsSystem.removeOnPointerDown(entity)
+    if (inputSystem.isTriggered(InputAction.IA_POINTER, PointerEventType.PET_DOWN, entity)) {
+      selectEntity(entity)
+      return
+    }
   }
 }
 
-/** Re-add pointer events on all discovered entities. */
+/** Restore each discovered entity's PointerEvents to the snapshot taken at
+ *  registration time. Called on editor-off so the scene's own click handlers
+ *  see their unmodified component again. */
+export function removeAllPointerEvents() {
+  for (const [entity, original] of originalPointerEvents) {
+    if (original === null) {
+      PointerEvents.deleteFrom(entity)
+    } else {
+      PointerEvents.createOrReplace(entity, original)
+    }
+  }
+}
+
+/** Re-add the editor's hover affordance to each registered entity, leaving
+ *  any user-added entries intact. Inverse of removeAllPointerEvents. */
 export function restoreAllPointerEvents() {
   for (const [entity, info] of selectableInfoMap) {
-    pointerEventsSystem.onPointerDown(
-      { entity, opts: { button: InputAction.IA_POINTER, hoverText: `Select ${info.name}`, maxDistance: 100 } },
-      () => {
-        if (!state.editorActive || state.isDragging || gizmoClickConsumed) return
-        selectEntity(entity)
-      }
-    )
+    addEditorHover(entity, info.name)
   }
 }

--- a/skills/editor-gizmo/src/__editor/index.ts
+++ b/skills/editor-gizmo/src/__editor/index.ts
@@ -25,7 +25,7 @@ import { Vector3 } from '@dcl/sdk/math'
 import { state, editorEntities, gizmoClickConsumed, setToggleHandler } from './state'
 import { setupEditorUi } from './ui'
 import { createEditorCamera, createLockCamera, deactivateEditorCamera, editorCameraSystem } from './camera'
-import { SKIP_ENTITIES, discoverySystem, removeAllPointerEvents, restoreAllPointerEvents } from './discovery'
+import { SKIP_ENTITIES, discoverySystem, editorClickSystem, removeAllPointerEvents, restoreAllPointerEvents } from './discovery'
 import { deselectEntity } from './selection'
 import { startDrag, startPlaneDrag, dragSystem } from './drag'
 import { gizmoFollowSystem, setStartDragHandler, setStartPlaneDragHandler } from './gizmo'
@@ -110,6 +110,7 @@ function setupClientEditor() {
 
   engine.addSystem(editorCameraSystem, 102)
   engine.addSystem(discoverySystem, 100)
+  engine.addSystem(editorClickSystem, 99)
   engine.addSystem(dragSystem)
   engine.addSystem(gizmoFollowSystem)
   engine.addSystem(modeToggleSystem)

--- a/skills/editor-gizmo/src/__editor/ui.tsx
+++ b/skills/editor-gizmo/src/__editor/ui.tsx
@@ -1,4 +1,4 @@
-import { Entity, Transform, VisibilityComponent } from '@dcl/sdk/ecs'
+import { Entity, Transform, VisibilityComponent, engine } from '@dcl/sdk/ecs'
 import { Color4, Quaternion } from '@dcl/sdk/math'
 import { isWeb } from '@dcl/sdk/platform'
 import ReactEcs, { ReactEcsRenderer, UiEntity, Label } from '@dcl/sdk/react-ecs'
@@ -7,7 +7,7 @@ import { toggleEditorCamera, focusSelectedEntity } from './camera'
 import { createGizmo } from './gizmo'
 import { undoCount, redoCount, undo, redo } from './history'
 import { selectEntity, deselectEntity } from './selection'
-import { state, selectableInfoMap, toggleEditorActive } from './state'
+import { state, selectableInfoMap, toggleEditorActive, editorEntities } from './state'
 
 // ── Platform detection ──────────────────────────────────
 
@@ -693,5 +693,7 @@ function EditorUI() {
 }
 
 export function setupEditorUi() {
-  ReactEcsRenderer.setUiRenderer(EditorUI, { virtualWidth: 1280, virtualHeight: 720 })
+  const uiEntity = engine.addEntity()
+  editorEntities.add(uiEntity)
+  ReactEcsRenderer.addUiRenderer(uiEntity, EditorUI, { virtualWidth: 1280, virtualHeight: 720 })
 }


### PR DESCRIPTION
## Summary
- The editor's discovery system was calling \`pointerEventsSystem.onPointerDown\` per discovered entity, which overwrites whatever callback the scene's own code registered (the helper keeps a single callback per entity). Scenes with click handlers on orbs / doors / NPCs became unresponsive as soon as the editor was added. Fix: capture each entity's existing \`PointerEvents\` snapshot, push a "Select <name>" hover entry alongside the user's entries, detect clicks via \`inputSystem.isTriggered(IA_POINTER, PET_DOWN, entity)\` polling instead of registering a callback.
- The editor UI was mounted via \`ReactEcsRenderer.setUiRenderer\`, which is the single "main" slot — installing the editor evicted the scene's own UI. Fix: mount via \`addUiRenderer\` on a dedicated entity so the editor composes alongside the scene UI instead of replacing it.

## What could break
- The editor adds a "Select <name>" hover entry on every discoverable entity. On entities the user also configured hover text for, both texts will show. Acceptable trade-off — alternative was breaking user click handlers entirely.
- \`addUiRenderer\` is associated with an entity; we add that entity to \`editorEntities\` so discovery doesn't try to treat it as selectable.

## How to test
- [ ] Open a scene with click handlers (orb / drawer / NPC). Toggle the editor on, click the entity → both scene behavior fires and the entity gets selected in the editor. Toggle off → only scene behavior fires.
- [ ] Open a scene with its own UI. Add the editor → both UIs render.